### PR TITLE
geom_alt props

### DIFF
--- a/data/421/179/961/421179961.geojson
+++ b/data/421/179/961/421179961.geojson
@@ -522,6 +522,9 @@
     },
     "wof:country":"SS",
     "wof:created":1459009239,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"7a27390ca20d9ef74ed307074922711c",
     "wof:hierarchy":[
         {
@@ -533,7 +536,7 @@
         }
     ],
     "wof:id":421179961,
-    "wof:lastmodified":1566650430,
+    "wof:lastmodified":1582319579,
     "wof:name":"Juba",
     "wof:parent_id":1091915677,
     "wof:placetype":"locality",

--- a/data/856/326/57/85632657.geojson
+++ b/data/856/326/57/85632657.geojson
@@ -720,8 +720,9 @@
     "qs:source":"US State Department, with Natural Earth mods",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "meso",
         "naturalearth",
-        "meso"
+        "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -765,6 +766,11 @@
     },
     "wof:country":"SS",
     "wof:country_alpha3":"SSD",
+    "wof:geom_alt":[
+        "meso",
+        "naturalearth-display-terrestrial-zoom6",
+        "naturalearth"
+    ],
     "wof:geomhash":"d7ae1bc61180b71f1df6ce4f1c7fd5a1",
     "wof:hierarchy":[
         {
@@ -779,7 +785,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650058,
+    "wof:lastmodified":1582319571,
     "wof:name":"South Sudan",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/326/57/85632657.geojson
+++ b/data/856/326/57/85632657.geojson
@@ -721,7 +721,6 @@
     "src:geom":"quattroshapes",
     "src:geom_alt":[
         "meso",
-        "naturalearth",
         "naturalearth"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -785,7 +784,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1582319571,
+    "wof:lastmodified":1583206336,
     "wof:name":"South Sudan",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/769/35/85676935.geojson
+++ b/data/856/769/35/85676935.geojson
@@ -300,6 +300,9 @@
         "wk:page":"Northern Bahr el Ghazal"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"221850c890e280cfef3653ea1c9e4103",
     "wof:hierarchy":[
         {
@@ -315,7 +318,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650053,
+    "wof:lastmodified":1582319567,
     "wof:name":"North Bahr-al-Ghazal",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/39/85676939.geojson
+++ b/data/856/769/39/85676939.geojson
@@ -294,6 +294,9 @@
         "wk:page":"Lakes (state)"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e8816e7bc031b1111208e01be2bdd065",
     "wof:hierarchy":[
         {
@@ -309,7 +312,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650056,
+    "wof:lastmodified":1582319569,
     "wof:name":"Lakes",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/45/85676945.geojson
+++ b/data/856/769/45/85676945.geojson
@@ -299,6 +299,9 @@
         "wk:page":"Western Equatoria"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f15faa5cdbc5fe291e9a6dd0bcf7ef2",
     "wof:hierarchy":[
         {
@@ -314,7 +317,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650054,
+    "wof:lastmodified":1582319567,
     "wof:name":"West Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/47/85676947.geojson
+++ b/data/856/769/47/85676947.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Central Equatoria"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"4f9a0162dc41cf018e8b1be3d32cf2e5",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650057,
+    "wof:lastmodified":1582319570,
     "wof:name":"Central Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/53/85676953.geojson
+++ b/data/856/769/53/85676953.geojson
@@ -303,6 +303,9 @@
         "wk:page":"Upper Nile (state)"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"03af51d9e3fb717a93abf260292db33b",
     "wof:hierarchy":[
         {
@@ -318,7 +321,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650055,
+    "wof:lastmodified":1582319568,
     "wof:name":"Upper Nile",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/57/85676957.geojson
+++ b/data/856/769/57/85676957.geojson
@@ -298,6 +298,9 @@
         "wk:page":"Jonglei"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e4b40fb8cd59ab3309909e607af723f9",
     "wof:hierarchy":[
         {
@@ -313,7 +316,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650052,
+    "wof:lastmodified":1582319567,
     "wof:name":"Jungoli",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/63/85676963.geojson
+++ b/data/856/769/63/85676963.geojson
@@ -306,6 +306,9 @@
         "wk:page":"Unity State"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db663ec44e90ea71841904e524fb15a2",
     "wof:hierarchy":[
         {
@@ -321,7 +324,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650056,
+    "wof:lastmodified":1582319569,
     "wof:name":"Unity",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/65/85676965.geojson
+++ b/data/856/769/65/85676965.geojson
@@ -297,6 +297,9 @@
         "wk:page":"Warrap (state)"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8df9cb1a4c7eae484c2adf81db0adfac",
     "wof:hierarchy":[
         {
@@ -312,7 +315,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650055,
+    "wof:lastmodified":1582319568,
     "wof:name":"Warap",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/71/85676971.geojson
+++ b/data/856/769/71/85676971.geojson
@@ -310,6 +310,9 @@
         "wk:page":"Western Bahr el Ghazal"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9891a378b064e8773e0b3d39c4ccf796",
     "wof:hierarchy":[
         {
@@ -325,7 +328,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650056,
+    "wof:lastmodified":1582319569,
     "wof:name":"West Bahr-al-Ghazal",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/75/85676975.geojson
+++ b/data/856/769/75/85676975.geojson
@@ -312,6 +312,9 @@
         "wk:page":"Eastern Equatoria"
     },
     "wof:country":"SS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"08d0bb371acd1c50b09385126ef02804",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566650054,
+    "wof:lastmodified":1582319568,
     "wof:name":"East Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/890/452/095/890452095.geojson
+++ b/data/890/452/095/890452095.geojson
@@ -94,6 +94,9 @@
     },
     "wof:country":"SS",
     "wof:created":1469052805,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5849a0c23edc0871fe29ae5e02b43722",
     "wof:hierarchy":[
         {
@@ -104,7 +107,7 @@
         }
     ],
     "wof:id":890452095,
-    "wof:lastmodified":1566650431,
+    "wof:lastmodified":1582319579,
     "wof:name":"Magwi",
     "wof:parent_id":85676975,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.