### PR TITLE
Name updates

### DIFF
--- a/data/856/326/57/85632657.geojson
+++ b/data/856/326/57/85632657.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":52.637921,
-    "geom:area_square_m":645221111981.293335,
+    "geom:area_square_m":645221117518.359131,
     "geom:bbox":"23.440849,3.488987,35.948997,12.236389",
     "geom:latitude":7.332293,
     "geom:longitude":30.202165,
@@ -34,6 +34,9 @@
     "name:afr_x_preferred":[
         "Suid-Soedan"
     ],
+    "name:aka_x_preferred":[
+        "South Sudan"
+    ],
     "name:als_x_preferred":[
         "S\u00fcdsudan"
     ],
@@ -51,6 +54,9 @@
     ],
     "name:arg_x_preferred":[
         "Sud\u00e1n d'o Sud"
+    ],
+    "name:ary_x_preferred":[
+        "\u062c\u0646\u0648\u0628 \u0633\u0648\u062f\u0627\u0646"
     ],
     "name:arz_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u0627\u0644\u0633\u0648\u062f\u0627\u0646"
@@ -72,6 +78,9 @@
     ],
     "name:bam_x_preferred":[
         "Worodugu Soudan"
+    ],
+    "name:ban_x_preferred":[
+        "Sudan Selatan"
     ],
     "name:bcl_x_preferred":[
         "Habagatan Sudan"
@@ -136,6 +145,9 @@
     "name:dan_x_preferred":[
         "Sydsudan"
     ],
+    "name:deu_ch_x_preferred":[
+        "S\u00fcdsudan"
+    ],
     "name:deu_x_preferred":[
         "S\u00fcdsudan"
     ],
@@ -156,6 +168,12 @@
     ],
     "name:ell_x_variant":[
         "\u0394\u03b7\u03bc\u03bf\u03ba\u03c1\u03b1\u03c4\u03af\u03b1 \u03c4\u03bf\u03c5 \u039d\u03cc\u03c4\u03b9\u03bf\u03c5 \u03a3\u03bf\u03c5\u03b4\u03ac\u03bd"
+    ],
+    "name:eng_ca_x_preferred":[
+        "South Sudan"
+    ],
+    "name:eng_gb_x_preferred":[
+        "South Sudan"
     ],
     "name:eng_x_preferred":[
         "South Sudan"
@@ -381,6 +399,9 @@
     "name:mkd_x_preferred":[
         "\u0408\u0443\u0436\u0435\u043d \u0421\u0443\u0434\u0430\u043d"
     ],
+    "name:mlg_x_preferred":[
+        "Sod\u00e0na Atsimo"
+    ],
     "name:mlt_x_preferred":[
         "Sudan t'Isfel"
     ],
@@ -534,6 +555,12 @@
     "name:srd_x_preferred":[
         "Sudan Meridionali"
     ],
+    "name:srp_ec_x_preferred":[
+        "\u0408\u0443\u0436\u043d\u0438 \u0421\u0443\u0434\u0430\u043d"
+    ],
+    "name:srp_el_x_preferred":[
+        "Ju\u017eni Sudan"
+    ],
     "name:srp_x_preferred":[
         "\u0408\u0443\u0436\u043d\u0438 \u0421\u0443\u0434\u0430\u043d"
     ],
@@ -554,6 +581,9 @@
     ],
     "name:szl_x_preferred":[
         "Po\u0142ed\u0144owy Sudan"
+    ],
+    "name:szy_x_preferred":[
+        "South sudan"
     ],
     "name:tam_x_preferred":[
         "\u0ba4\u0bc6\u0bb1\u0bcd\u0b95\u0bc1 \u0b9a\u0bc2\u0b9f\u0bbe\u0ba9\u0bcd"
@@ -630,8 +660,14 @@
     "name:zha_x_preferred":[
         "Namz Sudan"
     ],
+    "name:zho_cn_x_preferred":[
+        "\u5357\u82cf\u4e39"
+    ],
     "name:zho_min_nan_x_preferred":[
         "L\u00e2m Sudan"
+    ],
+    "name:zho_tw_x_preferred":[
+        "\u5357\u8607\u4e39"
     ],
     "name:zho_x_preferred":[
         "\u5357\u8607\u4e39"
@@ -785,7 +821,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1583797433,
+    "wof:lastmodified":1587427962,
     "wof:name":"South Sudan",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/890/441/679/890441679.geojson
+++ b/data/890/441/679/890441679.geojson
@@ -119,7 +119,7 @@
         "\u0644\u06cc\u06cc\u0631 \u060c \u0633\u0627\u0624\u062a\u06be \u0633\u0648\u0688\u0627\u0646"
     ],
     "name:urd_x_variant":[
-        "\u0644\u06cc\u06cc\u0631 "
+        "\u0644\u06cc\u06cc\u0631"
     ],
     "name:vie_x_preferred":[
         "Leer"
@@ -132,8 +132,8 @@
     "wof:belongsto":[
         102191573,
         85632657,
-        85676963,
-        1091915755
+        1091915755,
+        85676963
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -155,7 +155,7 @@
         }
     ],
     "wof:id":890441679,
-    "wof:lastmodified":1566650431,
+    "wof:lastmodified":1587163142,
     "wof:name":"Ler",
     "wof:parent_id":1091915755,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes https://github.com/whosonfirst-data/whosonfirst-data/issues/1796 and https://github.com/whosonfirst-data/whosonfirst-data/issues/1821.

This PR includes:
- Fixes to property values that start or end with `" "`, `\n`, or `\r`, removing those characters.
- Using a modified version of the [wiki names import script](https://github.com/whosonfirst/whosonfirst-cookbook/blob/master/scripts/crawl_to_add_wiki_names.py), adds new `name` properties

There will be ~260 similar PRs, one for each per-country repo. No PIP work require, can merge as-is.