### PR TITLE
add name properties from wikidata

### DIFF
--- a/data/102/546/303/102546303.geojson
+++ b/data/102/546/303/102546303.geojson
@@ -22,6 +22,9 @@
     "name:ceb_x_preferred":[
         "Juba Airport"
     ],
+    "name:cym_x_preferred":[
+        "Maes Awyr Rhyngwladol Juba"
+    ],
     "name:deu_x_preferred":[
         "Flughafen Juba"
     ],
@@ -38,11 +41,17 @@
     "name:heb_x_preferred":[
         "\u05e0\u05de\u05dc \u05d4\u05ea\u05e2\u05d5\u05e4\u05d4 \u05d2'\u05d5\u05d1\u05d4"
     ],
+    "name:hun_x_preferred":[
+        "Jubai nemzetk\u00f6zi rep\u00fcl\u0151t\u00e9r"
+    ],
     "name:ind_x_preferred":[
         "Bandar Udara Juba"
     ],
     "name:jpn_x_preferred":[
         "\u30b8\u30e5\u30d0\u7a7a\u6e2f"
+    ],
+    "name:kor_x_preferred":[
+        "\uc8fc\ubc14 \uad6d\uc81c\uacf5\ud56d"
     ],
     "name:lit_x_preferred":[
         "D\u017eubos oro uostas"
@@ -114,7 +123,7 @@
         }
     ],
     "wof:id":102546303,
-    "wof:lastmodified":1631745406,
+    "wof:lastmodified":1690866736,
     "wof:name":"Juba Airport",
     "wof:parent_id":85676947,
     "wof:placetype":"campus",

--- a/data/114/190/696/3/1141906963.geojson
+++ b/data/114/190/696/3/1141906963.geojson
@@ -21,10 +21,16 @@
     "name:ara_x_preferred":[
         "\u0645\u064a\u0644\u0648\u062a"
     ],
+    "name:ast_x_preferred":[
+        "Melut"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09c7\u09b2\u09c1\u09a4"
     ],
     "name:dan_x_preferred":[
+        "Melut"
+    ],
+    "name:deu_x_preferred":[
         "Melut"
     ],
     "name:ell_x_preferred":[
@@ -248,7 +254,7 @@
         }
     ],
     "wof:id":1141906963,
-    "wof:lastmodified":1636496026,
+    "wof:lastmodified":1690866749,
     "wof:name":"Melut",
     "wof:parent_id":1091914927,
     "wof:placetype":"locality",

--- a/data/114/190/696/5/1141906965.geojson
+++ b/data/114/190/696/5/1141906965.geojson
@@ -21,6 +21,9 @@
     "name:ara_x_preferred":[
         "\u0627\u0644\u0646\u0627\u0635\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0644\u0646\u0627\u0635\u0631"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09be\u09b8\u09bf\u09b0"
     ],
@@ -101,6 +104,9 @@
     ],
     "name:zho_x_preferred":[
         "\u7d0d\u5915\u723e"
+    ],
+    "name:zho_x_variant":[
+        "\u7d0d\u897f\u723e"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
@@ -221,7 +227,7 @@
         }
     ],
     "wof:id":1141906965,
-    "wof:lastmodified":1636496026,
+    "wof:lastmodified":1690866749,
     "wof:name":"Nasir",
     "wof:parent_id":1091913609,
     "wof:placetype":"locality",

--- a/data/114/190/884/7/1141908847.geojson
+++ b/data/114/190/884/7/1141908847.geojson
@@ -24,6 +24,9 @@
     "name:ara_x_variant":[
         "\u0646\u0645\u0648\u0644\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0646\u0645\u0648\u0644\u0649"
+    ],
     "name:ben_x_preferred":[
         "\u09a8\u09bf\u09ae\u09c1\u09b2"
     ],
@@ -123,6 +126,9 @@
     "name:srp_x_preferred":[
         "\u041d\u0438\u043c\u0443\u043b\u0435"
     ],
+    "name:swa_x_preferred":[
+        "Nimule"
+    ],
     "name:swe_x_preferred":[
         "Nimule"
     ],
@@ -149,6 +155,9 @@
     ],
     "name:zho_x_preferred":[
         "\u5c3c\u7a46\u840a"
+    ],
+    "name:zul_x_preferred":[
+        "Nimule"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
@@ -269,7 +278,7 @@
         }
     ],
     "wof:id":1141908847,
-    "wof:lastmodified":1636496026,
+    "wof:lastmodified":1690866749,
     "wof:name":"Nimule",
     "wof:parent_id":890452095,
     "wof:placetype":"locality",

--- a/data/421/167/093/421167093.geojson
+++ b/data/421/167/093/421167093.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0645\u0627\u0631\u064a\u062f\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0627\u0631\u064a\u062f\u0649"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b0\u09bf\u09a6\u09bf"
     ],
@@ -94,6 +97,9 @@
     ],
     "name:urd_x_preferred":[
         "\u0645\u0627\u0631\u06cc\u0688\u06cc"
+    ],
+    "name:vie_x_preferred":[
+        "Maridi"
     ],
     "name:zho_x_preferred":[
         "\u99ac\u91cc\u8fea"
@@ -238,7 +244,7 @@
         }
     ],
     "wof:id":421167093,
-    "wof:lastmodified":1636496021,
+    "wof:lastmodified":1690866744,
     "wof:name":"Maridi",
     "wof:parent_id":1091914455,
     "wof:placetype":"locality",

--- a/data/421/168/713/421168713.geojson
+++ b/data/421/168/713/421168713.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0631\u0645\u0628\u064a\u0643"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0645\u0628\u064a\u0643"
+    ],
     "name:ben_x_preferred":[
         "\u09b0\u09c1\u09ae\u09ac\u09c7\u0995"
     ],
@@ -167,6 +170,9 @@
     "name:zho_x_preferred":[
         "\u502b\u8c9d\u514b"
     ],
+    "name:zul_x_preferred":[
+        "Rumbek"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
     "ne:ADM0_A3":"SSD",
@@ -307,7 +313,7 @@
         }
     ],
     "wof:id":421168713,
-    "wof:lastmodified":1636496021,
+    "wof:lastmodified":1690866743,
     "wof:name":"Rumbek",
     "wof:parent_id":1091916013,
     "wof:placetype":"locality",

--- a/data/421/168/717/421168717.geojson
+++ b/data/421/168/717/421168717.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0642\u0648\u0642\u0631\u064a\u0627\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u062c\u0648\u0642\u0631\u064a\u0627\u0644"
+    ],
     "name:azb_x_preferred":[
         "\u0642\u0648\u0642\u0631\u06cc\u0627\u0644"
     ],
@@ -34,6 +37,9 @@
     ],
     "name:deu_x_preferred":[
         "Gogrial"
+    ],
+    "name:din_x_preferred":[
+        "Agu\u0254\u0254k"
     ],
     "name:ell_x_preferred":[
         "\u0393\u03ba\u03bf\u03b3\u03ba\u03c1\u03b9\u03ac\u03bb"
@@ -103,6 +109,9 @@
     ],
     "name:urd_x_preferred":[
         "\u06af\u0627\u06af\u0631\u06cc\u0627\u0644"
+    ],
+    "name:vie_x_preferred":[
+        "Gogrial"
     ],
     "name:zho_x_preferred":[
         "\u6208\u683c\u91cc\u4e9e\u52d2"
@@ -247,7 +256,7 @@
         }
     ],
     "wof:id":421168717,
-    "wof:lastmodified":1636496021,
+    "wof:lastmodified":1690866744,
     "wof:name":"Gogrial",
     "wof:parent_id":1091915551,
     "wof:placetype":"locality",

--- a/data/421/171/247/421171247.geojson
+++ b/data/421/171/247/421171247.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0628\u0648\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0648\u0631"
+    ],
     "name:ben_x_preferred":[
         "\u09ac\u09b0"
     ],
@@ -48,6 +51,9 @@
         "Bor"
     ],
     "name:fra_x_preferred":[
+        "Bor"
+    ],
+    "name:gle_x_preferred":[
         "Bor"
     ],
     "name:guj_x_preferred":[
@@ -152,6 +158,9 @@
     "name:urd_x_variant":[
         "\u0628\u0648\u0631"
     ],
+    "name:vec_x_preferred":[
+        "Bor"
+    ],
     "name:vie_x_preferred":[
         "Bor"
     ],
@@ -160,6 +169,9 @@
     ],
     "name:zho_x_preferred":[
         "\u6ce2\u723e"
+    ],
+    "name:zul_x_preferred":[
+        "Bor"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
@@ -304,7 +316,7 @@
         }
     ],
     "wof:id":421171247,
-    "wof:lastmodified":1636496022,
+    "wof:lastmodified":1690866747,
     "wof:name":"Bor",
     "wof:parent_id":1091914581,
     "wof:placetype":"locality",

--- a/data/421/174/517/421174517.geojson
+++ b/data/421/174/517/421174517.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0643\u0628\u0648\u064a\u062a\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0643\u0628\u0648\u064a\u062a\u0627"
+    ],
     "name:ben_x_preferred":[
         "\u0995\u09be\u09aa\u09cb\u09df\u09c7\u09a4\u09be"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:urd_x_preferred":[
         "\u06a9\u0627\u067e\u0648\u0626\u06cc\u0679\u0627"
+    ],
+    "name:vie_x_preferred":[
+        "Kapoeta"
     ],
     "name:zho_x_preferred":[
         "\u5361\u6ce2\u57c3\u5854"
@@ -247,7 +253,7 @@
         }
     ],
     "wof:id":421174517,
-    "wof:lastmodified":1636496021,
+    "wof:lastmodified":1690866745,
     "wof:name":"Kapoeta",
     "wof:parent_id":1091915407,
     "wof:placetype":"locality",

--- a/data/421/174/937/421174937.geojson
+++ b/data/421/174/937/421174937.geojson
@@ -23,6 +23,9 @@
     "name:ara_x_preferred":[
         "\u064a\u0627\u064a"
     ],
+    "name:arz_x_preferred":[
+        "\u064a\u0627\u0649"
+    ],
     "name:ben_x_preferred":[
         "\u09a4\u09c7\u0987"
     ],
@@ -142,6 +145,9 @@
     ],
     "name:zho_x_preferred":[
         "\u8036\u4f0a"
+    ],
+    "name:zul_x_preferred":[
+        "Yei"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
@@ -283,7 +289,7 @@
         }
     ],
     "wof:id":421174937,
-    "wof:lastmodified":1566650429,
+    "wof:lastmodified":1690866745,
     "wof:name":"Yey",
     "wof:parent_id":1091914579,
     "wof:placetype":"locality",

--- a/data/421/177/341/421177341.geojson
+++ b/data/421/177/341/421177341.geojson
@@ -20,10 +20,16 @@
     "name:ara_x_preferred":[
         "\u064a\u064a\u0631\u0648\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u064a\u064a\u0631\u0648\u0644"
+    ],
     "name:bul_x_preferred":[
         "\u0418\u0439\u0440\u043e\u043b"
     ],
     "name:ceb_x_preferred":[
+        "Yirol"
+    ],
+    "name:deu_x_preferred":[
         "Yirol"
     ],
     "name:eng_x_preferred":[
@@ -56,8 +62,14 @@
     "name:urd_x_preferred":[
         "\u06cc\u0627\u0631\u0648\u0644"
     ],
+    "name:vie_x_preferred":[
+        "Yirol"
+    ],
     "name:zho_x_preferred":[
         "\u4f0a\u7f85\u52d2"
+    ],
+    "name:zul_x_preferred":[
+        "Yirol"
     ],
     "qs:gn_country":"SS",
     "qs:gn_fcode":"PPL",
@@ -106,7 +118,7 @@
         }
     ],
     "wof:id":421177341,
-    "wof:lastmodified":1566650430,
+    "wof:lastmodified":1690866746,
     "wof:name":"Yirol",
     "wof:parent_id":1091914585,
     "wof:placetype":"locality",

--- a/data/421/179/959/421179959.geojson
+++ b/data/421/179/959/421179959.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0645\u0644\u0643\u0627\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0645\u0644\u0643\u0627\u0644"
+    ],
+    "name:ast_x_preferred":[
+        "Malakal"
+    ],
     "name:ben_x_preferred":[
         "\u09ae\u09be\u09b2\u09be\u0995\u09be\u09b2"
     ],
@@ -53,10 +59,16 @@
     "name:est_x_preferred":[
         "Malakal"
     ],
+    "name:fas_x_preferred":[
+        "\u0645\u0627\u0644\u0627\u06a9\u0627\u0644"
+    ],
     "name:fin_x_preferred":[
         "Malakal"
     ],
     "name:fra_x_preferred":[
+        "Malakal"
+    ],
+    "name:gle_x_preferred":[
         "Malakal"
     ],
     "name:guj_x_preferred":[
@@ -76,6 +88,9 @@
     ],
     "name:hun_x_preferred":[
         "Malakal"
+    ],
+    "name:hye_x_preferred":[
+        "\u0544\u0561\u056c\u0561\u056f\u0561\u056c"
     ],
     "name:ind_x_preferred":[
         "Malakal"
@@ -167,6 +182,9 @@
     "name:urd_x_preferred":[
         "\u0645\u0644\u06a9\u0627\u0644"
     ],
+    "name:vec_x_preferred":[
+        "Malakal"
+    ],
     "name:vie_x_preferred":[
         "Malakal"
     ],
@@ -175,6 +193,12 @@
     ],
     "name:zho_x_preferred":[
         "\u99ac\u62c9\u5361\u723e"
+    ],
+    "name:zho_x_variant":[
+        "\u99ac\u62c9\u5361\u52d2"
+    ],
+    "name:zul_x_preferred":[
+        "Malakal"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
@@ -318,7 +342,7 @@
         }
     ],
     "wof:id":421179959,
-    "wof:lastmodified":1636496022,
+    "wof:lastmodified":1690866747,
     "wof:name":"Malakal",
     "wof:parent_id":1091915845,
     "wof:placetype":"locality",

--- a/data/421/179/961/421179961.geojson
+++ b/data/421/179/961/421179961.geojson
@@ -19,6 +19,9 @@
     "mz:is_current":1,
     "mz:min_zoom":5.1,
     "mz:note":"quattroshapes points import (201603)",
+    "name:abk_x_preferred":[
+        "\u040f\u0443\u0431\u0430"
+    ],
     "name:afr_x_preferred":[
         "Joeba"
     ],
@@ -28,20 +31,35 @@
     "name:ara_x_preferred":[
         "\u062c\u0648\u0628\u0627"
     ],
+    "name:arg_x_preferred":[
+        "Juba"
+    ],
+    "name:ary_x_preferred":[
+        "\u062c\u0648\u0628\u0627"
+    ],
     "name:arz_x_preferred":[
         "\u062c\u0648\u0628\u0627"
     ],
     "name:ast_x_preferred":[
         "Yuba"
     ],
+    "name:ast_x_variant":[
+        "Juba"
+    ],
     "name:ava_x_preferred":[
         "\u0414\u0436\u0443\u0431\u0430"
+    ],
+    "name:avk_x_preferred":[
+        "Juba"
     ],
     "name:azb_x_preferred":[
         "\u062c\u0648\u0628\u0627"
     ],
     "name:aze_x_preferred":[
         "Cuba"
+    ],
+    "name:ban_x_preferred":[
+        "Juba"
     ],
     "name:bcl_x_preferred":[
         "Juba"
@@ -106,6 +124,9 @@
     "name:epo_x_preferred":[
         "\u0134ubo"
     ],
+    "name:epo_x_variant":[
+        "\u011cubao"
+    ],
     "name:est_x_preferred":[
         "Juba"
     ],
@@ -136,10 +157,16 @@
     "name:glg_x_preferred":[
         "Juba"
     ],
+    "name:grn_x_preferred":[
+        "J\u00fava"
+    ],
     "name:guj_x_preferred":[
         "\u0a9c\u0ac1\u0aac\u0abe"
     ],
     "name:hak_x_preferred":[
+        "Juba"
+    ],
+    "name:hau_x_preferred":[
         "Juba"
     ],
     "name:hbs_x_preferred":[
@@ -211,6 +238,9 @@
     "name:lav_x_preferred":[
         "D\u017e\u016bba"
     ],
+    "name:lfn_x_preferred":[
+        "Juba"
+    ],
     "name:lij_x_preferred":[
         "Juba"
     ],
@@ -241,6 +271,12 @@
     "name:msa_x_preferred":[
         "Juba"
     ],
+    "name:mya_x_preferred":[
+        "\u1002\u103b\u1030\u1018\u102c\u1019\u103c\u102d\u102f\u1037"
+    ],
+    "name:mzn_x_preferred":[
+        "\u062c\u0648\u0628\u0627"
+    ],
     "name:nah_x_preferred":[
         "Yuba"
     ],
@@ -262,6 +298,9 @@
     "name:oci_x_preferred":[
         "Juba"
     ],
+    "name:oss_x_preferred":[
+        "\u0414\u0436\u0443\u0431\u00e6"
+    ],
     "name:pam_x_preferred":[
         "Juba"
     ],
@@ -271,8 +310,14 @@
     "name:pap_x_preferred":[
         "Juba"
     ],
+    "name:pih_x_preferred":[
+        "Juba"
+    ],
     "name:pms_x_preferred":[
         "Juba"
+    ],
+    "name:pnb_x_preferred":[
+        "\u062c\u0648\u0628\u0627"
     ],
     "name:pol_x_preferred":[
         "D\u017cuba"
@@ -304,6 +349,15 @@
     "name:slv_x_preferred":[
         "D\u017euba"
     ],
+    "name:sme_x_preferred":[
+        "Juba"
+    ],
+    "name:smn_x_preferred":[
+        "Juba"
+    ],
+    "name:sms_x_preferred":[
+        "Juba"
+    ],
     "name:sna_x_preferred":[
         "Juba"
     ],
@@ -315,6 +369,9 @@
     ],
     "name:sqi_x_preferred":[
         "Xhuba"
+    ],
+    "name:srd_x_preferred":[
+        "Juba"
     ],
     "name:srp_x_preferred":[
         "\u040f\u0443\u0431\u0430"
@@ -330,6 +387,9 @@
     ],
     "name:tel_x_preferred":[
         "\u0c2f\u0c42\u0c2c\u0c3e"
+    ],
+    "name:tgk_x_preferred":[
+        "\u04b6\u0443\u0431\u0430"
     ],
     "name:tgl_x_preferred":[
         "Juba"
@@ -384,6 +444,9 @@
     ],
     "name:zho_yue_x_preferred":[
         "\u6731\u5df4"
+    ],
+    "name:zul_x_preferred":[
+        "Juba"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
@@ -508,8 +571,8 @@
     "wof:belongsto":[
         102191573,
         85632657,
-        1091915677,
-        85676947
+        85676947,
+        1091915677
     ],
     "wof:breaches":[],
     "wof:capital_of":[
@@ -538,7 +601,7 @@
         }
     ],
     "wof:id":421179961,
-    "wof:lastmodified":1607390902,
+    "wof:lastmodified":1690866746,
     "wof:name":"Juba",
     "wof:parent_id":1091915677,
     "wof:placetype":"locality",

--- a/data/421/180/375/421180375.geojson
+++ b/data/421/180/375/421180375.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u062a\u0648\u0646\u062c"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0648\u0646\u062c"
+    ],
     "name:azb_x_preferred":[
         "\u062a\u0648\u0646\u062c"
     ],
@@ -143,6 +146,9 @@
     "name:zho_x_preferred":[
         "\u901a\u5b63"
     ],
+    "name:zul_x_preferred":[
+        "Tonj"
+    ],
     "qs:gn_country":"SS",
     "qs:gn_fcode":"PPL",
     "qs:gn_id":365763,
@@ -191,7 +197,7 @@
         }
     ],
     "wof:id":421180375,
-    "wof:lastmodified":1566650429,
+    "wof:lastmodified":1690866745,
     "wof:name":"Tonj",
     "wof:parent_id":1091914221,
     "wof:placetype":"locality",

--- a/data/421/183/531/421183531.geojson
+++ b/data/421/183/531/421183531.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u0631\u0627\u062c\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u0631\u0627\u062c\u0627"
+    ],
     "name:ceb_x_preferred":[
         "Raja"
     ],
@@ -56,8 +59,17 @@
     "name:swe_x_preferred":[
         "Raja"
     ],
+    "name:tur_x_preferred":[
+        "Raga"
+    ],
+    "name:ukr_x_preferred":[
+        "\u0420\u0430\u0433\u0430"
+    ],
     "name:und_x_variant":[
         "Ragaa"
+    ],
+    "name:vie_x_preferred":[
+        "Raga"
     ],
     "name:zho_x_preferred":[
         "\u62c9\u52a0"
@@ -110,7 +122,7 @@
         }
     ],
     "wof:id":421183531,
-    "wof:lastmodified":1566650430,
+    "wof:lastmodified":1690866746,
     "wof:name":"Raga",
     "wof:parent_id":1091915153,
     "wof:placetype":"locality",

--- a/data/421/197/347/421197347.geojson
+++ b/data/421/197/347/421197347.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u062a\u0648\u0645\u0628\u0648\u0631\u0627"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0648\u0645\u0628\u0648\u0631\u0627"
+    ],
+    "name:ast_x_preferred":[
+        "Tumbura"
+    ],
     "name:ceb_x_preferred":[
         "Tambura"
     ],
@@ -52,6 +58,9 @@
     ],
     "name:swe_x_preferred":[
         "Tambura"
+    ],
+    "name:vie_x_preferred":[
+        "Tumbura"
     ],
     "name:zho_x_preferred":[
         "\u5766\u5e03\u62c9"
@@ -107,7 +116,7 @@
         }
     ],
     "wof:id":421197347,
-    "wof:lastmodified":1566650429,
+    "wof:lastmodified":1690866745,
     "wof:name":"Tambura",
     "wof:parent_id":1091915243,
     "wof:placetype":"locality",

--- a/data/421/200/265/421200265.geojson
+++ b/data/421/200/265/421200265.geojson
@@ -20,6 +20,9 @@
     "name:ara_x_preferred":[
         "\u064a\u0627\u0645\u0628\u064a\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u064a\u0627\u0645\u0628\u064a\u0648"
+    ],
     "name:azb_x_preferred":[
         "\u06cc\u0627\u0645\u0628\u06cc\u0648"
     ],
@@ -164,6 +167,9 @@
     "name:zho_x_preferred":[
         "\u5ef6\u6bd4\u5967"
     ],
+    "name:zul_x_preferred":[
+        "Yambio"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
     "ne:ADM0_A3":"SSD",
@@ -304,7 +310,7 @@
         }
     ],
     "wof:id":421200265,
-    "wof:lastmodified":1636496022,
+    "wof:lastmodified":1690866746,
     "wof:name":"Yambio",
     "wof:parent_id":1091916233,
     "wof:placetype":"locality",

--- a/data/421/200/267/421200267.geojson
+++ b/data/421/200/267/421200267.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u0623\u0648\u064a\u0644"
     ],
+    "name:arz_x_preferred":[
+        "\u0627\u0648\u064a\u0644"
+    ],
+    "name:ast_x_preferred":[
+        "Aweil"
+    ],
     "name:ben_x_preferred":[
         "\u0986\u09ac\u09bf\u09b2"
     ],
@@ -164,6 +170,9 @@
     "name:zho_x_preferred":[
         "\u963f\u7dad\u723e"
     ],
+    "name:zul_x_preferred":[
+        "Aweil"
+    ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
     "ne:ADM0_A3":"SSD",
@@ -306,7 +315,7 @@
         }
     ],
     "wof:id":421200267,
-    "wof:lastmodified":1566650429,
+    "wof:lastmodified":1690866745,
     "wof:name":"Uwayl",
     "wof:parent_id":1091915329,
     "wof:placetype":"locality",

--- a/data/421/202/345/421202345.geojson
+++ b/data/421/202/345/421202345.geojson
@@ -20,6 +20,12 @@
     "name:ara_x_preferred":[
         "\u062a\u0648\u0631\u064a\u062a"
     ],
+    "name:arz_x_preferred":[
+        "\u062a\u0648\u0631\u064a\u062a"
+    ],
+    "name:ast_x_preferred":[
+        "Torit"
+    ],
     "name:bre_x_preferred":[
         "Torit"
     ],
@@ -32,7 +38,13 @@
     "name:deu_x_preferred":[
         "Torit"
     ],
+    "name:ell_x_preferred":[
+        "\u03a4\u03bf\u03c1\u03af\u03c4"
+    ],
     "name:eng_x_preferred":[
+        "Torit"
+    ],
+    "name:fin_x_preferred":[
         "Torit"
     ],
     "name:fra_x_preferred":[
@@ -49,6 +61,9 @@
     ],
     "name:kor_x_preferred":[
         "\ud1a0\ub9ac\ud2b8"
+    ],
+    "name:lit_x_preferred":[
+        "Toritas"
     ],
     "name:nld_x_preferred":[
         "Torit"
@@ -77,14 +92,23 @@
     "name:swe_x_preferred":[
         "Torit"
     ],
+    "name:ukr_x_preferred":[
+        "\u0422\u043e\u0440\u0438\u0442"
+    ],
     "name:urd_x_preferred":[
         "\u062a\u0648\u0631\u06cc\u062a"
+    ],
+    "name:vie_x_preferred":[
+        "Torit"
     ],
     "name:war_x_preferred":[
         "Torit"
     ],
     "name:zho_x_preferred":[
         "\u6258\u91cc\u7279"
+    ],
+    "name:zul_x_preferred":[
+        "Torit"
     ],
     "qs:gn_country":"SS",
     "qs:gn_fcode":"PPLA",
@@ -137,7 +161,7 @@
         }
     ],
     "wof:id":421202345,
-    "wof:lastmodified":1566650429,
+    "wof:lastmodified":1690866744,
     "wof:name":"Torit",
     "wof:parent_id":1091914269,
     "wof:placetype":"locality",

--- a/data/421/203/053/421203053.geojson
+++ b/data/421/203/053/421203053.geojson
@@ -41,6 +41,9 @@
     "name:ceb_x_preferred":[
         "Wau"
     ],
+    "name:ces_x_preferred":[
+        "Wau"
+    ],
     "name:dan_x_preferred":[
         "Waw"
     ],
@@ -74,6 +77,9 @@
     "name:fra_x_preferred":[
         "Wau"
     ],
+    "name:gle_x_preferred":[
+        "Wau"
+    ],
     "name:guj_x_preferred":[
         "\u0ab5\u0abe\u0a89"
     ],
@@ -91,6 +97,9 @@
     ],
     "name:ita_x_preferred":[
         "W\u0101w"
+    ],
+    "name:ita_x_variant":[
+        "Wau"
     ],
     "name:jpn_x_preferred":[
         "\u30ef\u30fc\u30a6"
@@ -179,6 +188,9 @@
     "name:urd_x_variant":[
         "\u0648\u0627\u0648"
     ],
+    "name:vec_x_preferred":[
+        "Wau"
+    ],
     "name:vie_x_preferred":[
         "Wau"
     ],
@@ -190,6 +202,9 @@
     ],
     "name:zho_x_preferred":[
         "\u74e6\u70cf"
+    ],
+    "name:zul_x_preferred":[
+        "Wau"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
@@ -331,7 +346,7 @@
         }
     ],
     "wof:id":421203053,
-    "wof:lastmodified":1636496021,
+    "wof:lastmodified":1690866744,
     "wof:name":"Wau",
     "wof:parent_id":1091916187,
     "wof:placetype":"locality",

--- a/data/856/326/57/85632657.geojson
+++ b/data/856/326/57/85632657.geojson
@@ -28,6 +28,9 @@
     "mz:is_current":1,
     "mz:max_zoom":8.0,
     "mz:min_zoom":3.0,
+    "name:abk_x_preferred":[
+        "\u0410\u043b\u0430\u0434\u0430\u0442\u04d9\u0438 \u0421\u0443\u0434\u0430\u043d"
+    ],
     "name:ady_x_preferred":[
         "\u041a\u044a\u044b\u0431\u043b\u044d \u0421\u0443\u0434\u0430\u043d"
     ],
@@ -43,8 +46,14 @@
     "name:amh_x_preferred":[
         "\u12f0\u1261\u1265 \u1231\u12f3\u1295"
     ],
+    "name:ami_x_preferred":[
+        "South sudan"
+    ],
     "name:ang_x_preferred":[
         "S\u016b\u00fesudan"
+    ],
+    "name:anp_x_preferred":[
+        "\u0926\u0915\u094d\u0937\u093f\u0923 \u0938\u0942\u0921\u093e\u0928"
     ],
     "name:ara_x_preferred":[
         "\u062c\u0646\u0648\u0628 \u0627\u0644\u0633\u0648\u062f\u0627\u0646"
@@ -67,6 +76,9 @@
     "name:ava_x_preferred":[
         "\u042e\u0433\u0430\u043b\u044a\u0443\u043b\u0430\u0431 \u0421\u0443\u0434\u0430\u043d"
     ],
+    "name:avk_x_preferred":[
+        "Geesudana"
+    ],
     "name:azb_x_preferred":[
         "\u062c\u0646\u0648\u0628\u06cc \u0633\u0648\u062f\u0627\u0646"
     ],
@@ -82,6 +94,9 @@
     "name:ban_x_preferred":[
         "Sudan Selatan"
     ],
+    "name:bar_x_preferred":[
+        "Sidsudan"
+    ],
     "name:bcl_x_preferred":[
         "Habagatan Sudan"
     ],
@@ -93,6 +108,9 @@
     ],
     "name:bho_x_preferred":[
         "\u0926\u0915\u094d\u0916\u093f\u0928 \u0938\u0942\u0921\u093e\u0928"
+    ],
+    "name:bis_x_preferred":[
+        "Saot Sudan"
     ],
     "name:bjn_x_preferred":[
         "Sudan Salatan"
@@ -141,6 +159,9 @@
     ],
     "name:cym_x_preferred":[
         "De Sudan"
+    ],
+    "name:dag_x_preferred":[
+        "South Sudan"
     ],
     "name:dan_x_preferred":[
         "Sydsudan"
@@ -240,11 +261,20 @@
     "name:glv_x_preferred":[
         "Yn Toodaan Yiass"
     ],
+    "name:gpe_x_preferred":[
+        "South Sudan"
+    ],
+    "name:grn_x_preferred":[
+        "Yvy Sund\u00e3"
+    ],
     "name:gsw_x_preferred":[
         "S\u00fcdsudan"
     ],
     "name:guj_x_preferred":[
         "\u0aa6\u0a95\u0acd\u0ab7\u0abf\u0aa3 \u0ab8\u0ac2\u0aa1\u0abe\u0aa8"
+    ],
+    "name:gur_x_preferred":[
+        "South Sudan"
     ],
     "name:hak_x_preferred":[
         "N\u00e0m Sudan"
@@ -324,8 +354,17 @@
     "name:kbp_x_preferred":[
         "Sudaan\u0269 Had\u025b Ki\u014b"
     ],
+    "name:kcg_x_preferred":[
+        "Sudan A\u0331tak"
+    ],
+    "name:khm_x_preferred":[
+        "\u179f\u17ca\u17bc\u178a\u1784\u17cb\u1781\u17b6\u1784\u178f\u17d2\u1794\u17bc\u1784"
+    ],
     "name:kik_x_preferred":[
         "S\u0169dana ya Kuthini"
+    ],
+    "name:kin_x_preferred":[
+        "Sudani y\u2019Amajyepfo"
     ],
     "name:kir_x_preferred":[
         "\u0422\u04af\u0448\u0442\u04af\u043a \u0421\u0443\u0434\u0430\u043d"
@@ -341,6 +380,9 @@
     ],
     "name:kor_x_preferred":[
         "\ub0a8\uc218\ub2e8"
+    ],
+    "name:krj_x_preferred":[
+        "Sudan Nabagatnan"
     ],
     "name:ksh_x_preferred":[
         "S\u00fcdsudan"
@@ -372,6 +414,9 @@
     "name:lit_x_preferred":[
         "Piet\u0173 Sudanas"
     ],
+    "name:lld_x_preferred":[
+        "Sudan dl Sud"
+    ],
     "name:lmo_x_preferred":[
         "S\u00fcd Sudan"
     ],
@@ -387,6 +432,9 @@
     "name:lzh_x_preferred":[
         "\u5357\u8607\u4e39"
     ],
+    "name:mad_x_preferred":[
+        "Sudan Lao'"
+    ],
     "name:mal_x_preferred":[
         "\u0d26\u0d15\u0d4d\u0d37\u0d3f\u0d23 \u0d38\u0d41\u0d21\u0d3e\u0d7b"
     ],
@@ -396,6 +444,12 @@
     "name:mdf_x_preferred":[
         "\u041b\u044f\u043c\u0431\u0435\u0448\u0438\u0440\u0435\u043d\u044c \u0421\u0443\u0434\u0430\u043d"
     ],
+    "name:mhr_x_preferred":[
+        "\u041a\u0435\u0447\u044b\u0432\u0430\u043b\u0432\u0435\u043b \u0421\u0443\u0434\u0430\u043d"
+    ],
+    "name:min_x_preferred":[
+        "Sudan Selatan"
+    ],
     "name:mkd_x_preferred":[
         "\u0408\u0443\u0436\u0435\u043d \u0421\u0443\u0434\u0430\u043d"
     ],
@@ -404,6 +458,15 @@
     ],
     "name:mlt_x_preferred":[
         "Sudan t'Isfel"
+    ],
+    "name:mni_x_preferred":[
+        "\uabc8\uabe5 \uabc1\uabe8\uabd7\uabe5\uabdf"
+    ],
+    "name:mon_x_preferred":[
+        "\u04e8\u043c\u043d\u04e9\u0434 \u0421\u0443\u0434\u0430\u043d"
+    ],
+    "name:mri_x_preferred":[
+        "H\u016bt\u0101ne-ki-te-tonga"
     ],
     "name:mrj_x_preferred":[
         "\u041a\u0435\u0447\u04f9\u0432\u04d3\u043b\u0432\u0435\u043b \u0421\u0443\u0434\u0430\u043d"
@@ -477,8 +540,14 @@
     "name:pan_x_variant":[
         "\u0a26\u0a71\u0a16\u0a23\u0a40 \u0a38\u0a42\u0a21\u0a3e\u0a28"
     ],
+    "name:pap_x_preferred":[
+        "Sur Sudan"
+    ],
     "name:pih_x_preferred":[
         "Sowth Sudan"
+    ],
+    "name:pms_x_preferred":[
+        "Sud Sudan"
     ],
     "name:pnb_x_preferred":[
         "\u062f\u06a9\u06be\u0646 \u0633\u0648\u0688\u0627\u0646"
@@ -510,6 +579,12 @@
     "name:sag_x_preferred":[
         "Sud\u00e4an-Mbongo"
     ],
+    "name:sah_x_preferred":[
+        "\u0421\u043e\u0495\u0443\u0440\u0443\u0443 \u0421\u0443\u0434\u0430\u043d"
+    ],
+    "name:sat_x_preferred":[
+        "\u1c60\u1c5a\u1c67\u1c6e \u1c65\u1c69\u1c6b\u1c5f\u1c71"
+    ],
     "name:scn_x_preferred":[
         "Sudan d\u00fb Sud"
     ],
@@ -518,6 +593,9 @@
     ],
     "name:sgs_x_preferred":[
         "P\u0117it\u016b Sudans"
+    ],
+    "name:shn_x_preferred":[
+        "\u1019\u102d\u1030\u1004\u103a\u1038\u101e\u1030\u1087\u1010\u107c\u103a\u1087\u1078\u1062\u107c\u103a\u1038"
     ],
     "name:sin_x_preferred":[
         "\u0daf\u0d9a\u0dd4\u0dab\u0dd4 \u0dc3\u0dd4\u0da9\u0dcf\u0db1\u0dba"
@@ -530,6 +608,12 @@
     ],
     "name:sme_x_preferred":[
         "Lulli-Sudan"
+    ],
+    "name:smn_x_preferred":[
+        "Maad\u00e2-Sudan"
+    ],
+    "name:sms_x_preferred":[
+        "Saujj-Sudaan"
     ],
     "name:sna_x_preferred":[
         "South Sudan"
@@ -594,17 +678,26 @@
     "name:tel_x_preferred":[
         "\u0c26\u0c15\u0c4d\u0c37\u0c3f\u0c23 \u0c38\u0c42\u0c21\u0c3e\u0c28\u0c4d"
     ],
+    "name:tgk_x_preferred":[
+        "\u0421\u0443\u0434\u043e\u043d\u0438 \u04b6\u0430\u043d\u0443\u0431\u04e3"
+    ],
     "name:tgl_x_preferred":[
         "Timog Sudan"
     ],
     "name:tha_x_preferred":[
         "\u0e1b\u0e23\u0e30\u0e40\u0e17\u0e28\u0e40\u0e0b\u0e32\u0e17\u0e4c\u0e0b\u0e39\u0e14\u0e32\u0e19"
     ],
+    "name:trv_x_preferred":[
+        "South Sudan"
+    ],
     "name:tso_x_preferred":[
         "Sudan-Dzonga"
     ],
     "name:tuk_x_preferred":[
         "G\u00fcnorta Sudan"
+    ],
+    "name:tum_x_preferred":[
+        "South Sudan"
     ],
     "name:tur_x_preferred":[
         "G\u00fcney Sudan"
@@ -889,7 +982,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1618362170,
+    "wof:lastmodified":1690866741,
     "wof:name":"South Sudan",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/769/35/85676935.geojson
+++ b/data/856/769/35/85676935.geojson
@@ -65,6 +65,9 @@
         "North Bahr-al-Ghazal",
         "Northern Bahr el Ghazal"
     ],
+    "name:epo_x_preferred":[
+        "Norda Bahr el Ghazal"
+    ],
     "name:fin_x_preferred":[
         "Pohjoinen Bahr el-Ghazal"
     ],
@@ -103,6 +106,9 @@
     ],
     "name:kor_x_preferred":[
         "\ubd81\ubc14\ub974\uc54c\uac00\uc798 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\ubd81\ubc14\ub974\uc54c\uac00\uc798\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Zieme\u013cu Bahrelgaz\u0101la"
@@ -193,6 +199,9 @@
     ],
     "name:zho_x_variant":[
         "\u5317\u52a0\u624e\u52d2\u6cb3\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Northern Bahr el Ghazal"
     ],
     "ne:abbrev":"N. BaG.",
     "ne:adm0_a3":"SDS",
@@ -318,7 +327,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1614895995,
+    "wof:lastmodified":1690866737,
     "wof:name":"North Bahr-al-Ghazal",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/39/85676939.geojson
+++ b/data/856/769/39/85676939.geojson
@@ -109,6 +109,9 @@
     "name:kor_x_preferred":[
         "\ub808\uc774\ud06c\uc2a4 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ub808\uc774\ud06c\uc2a4\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Buheir\u0101ta"
     ],
@@ -192,6 +195,12 @@
     ],
     "name:zho_x_preferred":[
         "\u6e56\u6cca\u7701"
+    ],
+    "name:zho_x_variant":[
+        "\u6e56\u6cca\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Lakes"
     ],
     "ne:abbrev":"Lakes",
     "ne:adm0_a3":"SDS",
@@ -318,7 +327,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496011,
+    "wof:lastmodified":1690866738,
     "wof:name":"Lakes",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/45/85676945.geojson
+++ b/data/856/769/45/85676945.geojson
@@ -107,6 +107,9 @@
     "name:kor_x_preferred":[
         "\uc11c\uc5d0\ucf70\ud1a0\ub9ac\uc544 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uc11c\uc5d0\ucf70\ud1a0\ub9ac\uc544\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Rietumu Ekvatorija"
     ],
@@ -164,6 +167,9 @@
     "name:tam_x_preferred":[
         "\u0bae\u0bc7\u0bb1\u0bcd\u0b95\u0bc1  \u0b8f\u0b95\u0bc1\u0bb5\u0b9f\u0bcb\u0bb0\u0bbf\u0b86"
     ],
+    "name:tam_x_variant":[
+        "\u0bae\u0bc7\u0bb1\u0bcd\u0b95\u0bc1 \u0b8f\u0b95\u0bc1\u0bb5\u0b9f\u0bcb\u0bb0\u0bbf\u0b86"
+    ],
     "name:tel_x_preferred":[
         "\u0c2a\u0c36\u0c4d\u0c1a\u0c3f\u0c2e \u0c08\u0c15\u0c4d\u0c35\u0c46\u0c1f\u0c4b\u0c30\u0c3f\u0c2f\u0c3e"
     ],
@@ -190,6 +196,9 @@
     ],
     "name:zho_x_variant":[
         "\u897f\u8d64\u9053\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Western Equatoria"
     ],
     "ne:abbrev":"W. Eq.",
     "ne:adm0_a3":"SDS",
@@ -317,7 +326,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1614895996,
+    "wof:lastmodified":1690866737,
     "wof:name":"West Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/47/85676947.geojson
+++ b/data/856/769/47/85676947.geojson
@@ -114,6 +114,9 @@
     "name:kor_x_preferred":[
         "\uc911\uc559\uc5d0\ucf70\ud1a0\ub9ac\uc544 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uc911\uc559\uc5d0\ucf70\ud1a0\ub9ac\uc544\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Centr\u0101l\u0101 Ekvatorija"
     ],
@@ -206,6 +209,9 @@
     ],
     "name:zho_x_variant":[
         "\u4e2d\u8d64\u9053\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Central Equatoria"
     ],
     "ne:abbrev":"C. Eq.",
     "ne:adm0_a3":"SDS",
@@ -333,7 +339,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496012,
+    "wof:lastmodified":1690866740,
     "wof:name":"Central Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/53/85676953.geojson
+++ b/data/856/769/53/85676953.geojson
@@ -93,6 +93,9 @@
     "name:hin_x_preferred":[
         "\u090a\u092a\u0930\u0940 \u0928\u0940\u0932"
     ],
+    "name:hrv_x_preferred":[
+        "Gornji Nil"
+    ],
     "name:hun_x_preferred":[
         "Fels\u0151-N\u00edlus"
     ],
@@ -113,6 +116,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc0c1\ub098\uc77c \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc0c1\ub098\uc77c\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Aug\u0161n\u012bla"
@@ -200,6 +206,12 @@
     ],
     "name:zho_x_preferred":[
         "\u4e0a\u5c3c\u7f57\u7701"
+    ],
+    "name:zho_x_variant":[
+        "\u4e0a\u5c3c\u7f57\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Upper Nile"
     ],
     "ne:abbrev":"U.N.",
     "ne:adm0_a3":"SDS",
@@ -324,7 +336,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496011,
+    "wof:lastmodified":1690866738,
     "wof:name":"Upper Nile",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/57/85676957.geojson
+++ b/data/856/769/57/85676957.geojson
@@ -68,6 +68,9 @@
         "Jonglei State",
         "Jungoli"
     ],
+    "name:epo_x_preferred":[
+        "Jonglei"
+    ],
     "name:fas_x_preferred":[
         "\u062c\u0648\u0646\u0642\u0644\u06cc"
     ],
@@ -86,6 +89,9 @@
     "name:hin_x_preferred":[
         "\u091c\u094b\u0902\u0917\u0932\u0940"
     ],
+    "name:hye_x_preferred":[
+        "\u054b\u0578\u0576\u0563\u056c\u0565\u0575"
+    ],
     "name:ind_x_preferred":[
         "Junqali"
     ],
@@ -103,6 +109,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc885\uae00\ub808\uc774 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc885\uae00\ub808\uc774\uc8fc"
     ],
     "name:lav_x_preferred":[
         "D\u017e\u016bnkal\u012b"
@@ -190,6 +199,12 @@
     ],
     "name:zho_x_preferred":[
         "\u743c\u83b1\u7701"
+    ],
+    "name:zho_x_variant":[
+        "\u743c\u83b1\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Jonglei"
     ],
     "ne:abbrev":"Jung.",
     "ne:adm0_a3":"SDS",
@@ -316,7 +331,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1614895995,
+    "wof:lastmodified":1690866736,
     "wof:name":"Jungoli",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/63/85676963.geojson
+++ b/data/856/769/63/85676963.geojson
@@ -111,6 +111,9 @@
     "name:kor_x_preferred":[
         "\uc720\ub2c8\ud2f0 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\uc720\ub2c8\ud2f0\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Vahdas vil\u0101js"
     ],
@@ -203,6 +206,9 @@
     ],
     "name:zho_x_variant":[
         "\u7336\u5c3c\u63d0\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Unity"
     ],
     "ne:abbrev":"Unity",
     "ne:adm0_a3":"SDS",
@@ -330,7 +336,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496012,
+    "wof:lastmodified":1690866739,
     "wof:name":"Unity",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/65/85676965.geojson
+++ b/data/856/769/65/85676965.geojson
@@ -67,6 +67,9 @@
         "Warrap State",
         "Warap"
     ],
+    "name:epo_x_preferred":[
+        "Warrap"
+    ],
     "name:fas_x_preferred":[
         "\u0648\u0627\u0631\u0627\u0628"
     ],
@@ -102,6 +105,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc640\ub78d \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc640\ub78d\uc8fc"
     ],
     "name:lav_x_preferred":[
         "V\u0101r\u0101pa"
@@ -189,6 +195,12 @@
     ],
     "name:zho_x_preferred":[
         "\u74e6\u62c9\u5e03\u7701"
+    ],
+    "name:zho_x_variant":[
+        "\u74e6\u62c9\u535c\u5dde"
+    ],
+    "name:zul_x_preferred":[
+        "Warrap"
     ],
     "ne:abbrev":"War.",
     "ne:adm0_a3":"SDS",
@@ -315,7 +327,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1614895996,
+    "wof:lastmodified":1690866738,
     "wof:name":"Warap",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/71/85676971.geojson
+++ b/data/856/769/71/85676971.geojson
@@ -68,6 +68,9 @@
         "Western Bahr el Ghazal State",
         "West Bahr-al-Ghazal"
     ],
+    "name:epo_x_preferred":[
+        "Okcidenta Bahr el Ghazal"
+    ],
     "name:fin_x_preferred":[
         "L\u00e4ntinen Bahr el-Ghazal"
     ],
@@ -106,6 +109,9 @@
     ],
     "name:kor_x_preferred":[
         "\uc11c\ubc14\ub974\uc54c\uac00\uc798 \uc8fc"
+    ],
+    "name:kor_x_variant":[
+        "\uc11c\ubc14\ub974\uc54c\uac00\uc798\uc8fc"
     ],
     "name:lav_x_preferred":[
         "Rietumbahrelgaz\u0101la"
@@ -199,6 +205,9 @@
     ],
     "name:zho_x_variant":[
         "\u897f\u52a0\u624e\u52d2\u6cb3\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Western Bahr el Ghazal"
     ],
     "ne:abbrev":"W. BaG.",
     "ne:adm0_a3":"SDS",
@@ -328,7 +337,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1614895996,
+    "wof:lastmodified":1690866739,
     "wof:name":"West Bahr-al-Ghazal",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/75/85676975.geojson
+++ b/data/856/769/75/85676975.geojson
@@ -112,6 +112,9 @@
     "name:kor_x_preferred":[
         "\ub3d9\uc5d0\ucf70\ud1a0\ub9ac\uc544 \uc8fc"
     ],
+    "name:kor_x_variant":[
+        "\ub3d9\uc5d0\ucf70\ud1a0\ub9ac\uc544\uc8fc"
+    ],
     "name:lav_x_preferred":[
         "Austrumu Ekvatorija"
     ],
@@ -172,6 +175,9 @@
     "name:tam_x_preferred":[
         "\u0b95\u0bbf\u0bb4\u0b95\u0bcd\u0b95\u0bc1  \u0b8f\u0b95\u0bc1\u0bb5\u0b9f\u0bcb\u0bb0\u0bbf\u0baf"
     ],
+    "name:tam_x_variant":[
+        "\u0b95\u0bbf\u0bb4\u0b95\u0bcd\u0b95\u0bc1 \u0b8f\u0b95\u0bc1\u0bb5\u0b9f\u0bcb\u0bb0\u0bbf\u0baf"
+    ],
     "name:tel_x_preferred":[
         "\u0c24\u0c42\u0c30\u0c4d\u0c2a\u0c41 \u0c08\u0c15\u0c4d\u0c35\u0c1f\u0c4b\u0c30\u0c3f\u0c2f\u0c3e"
     ],
@@ -204,6 +210,9 @@
     ],
     "name:zho_x_variant":[
         "\u4e1c\u8d64\u9053\u7701"
+    ],
+    "name:zul_x_preferred":[
+        "Eastern Equatoria"
     ],
     "ne:abbrev":"E. Eq.",
     "ne:adm0_a3":"SDS",
@@ -330,7 +339,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1614895996,
+    "wof:lastmodified":1690866737,
     "wof:name":"East Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/890/441/257/890441257.geojson
+++ b/data/890/441/257/890441257.geojson
@@ -22,6 +22,12 @@
     "name:ara_x_preferred":[
         "\u0628\u0627\u0646\u062a\u064a\u0648"
     ],
+    "name:arz_x_preferred":[
+        "\u0628\u0627\u0646\u062a\u064a\u0648"
+    ],
+    "name:ast_x_preferred":[
+        "Bentiu"
+    ],
     "name:azb_x_preferred":[
         "\u0628\u0646\u062a\u06cc\u0648"
     ],
@@ -44,6 +50,9 @@
         "\u039c\u03c0\u03ad\u03bd\u03c4\u03b9\u03bf\u03c5"
     ],
     "name:eng_x_preferred":[
+        "Bentiu"
+    ],
+    "name:eus_x_preferred":[
         "Bentiu"
     ],
     "name:fas_x_preferred":[
@@ -165,6 +174,12 @@
     ],
     "name:zho_x_preferred":[
         "\u73ed\u63d0\u70cf"
+    ],
+    "name:zho_x_variant":[
+        "\u672c\u63d0\u4e4c"
+    ],
+    "name:zul_x_preferred":[
+        "Bentiu"
     ],
     "ne:ADM0CAP":0.0,
     "ne:ADM0NAME":"South Sudan",
@@ -294,7 +309,7 @@
         }
     ],
     "wof:id":890441257,
-    "wof:lastmodified":1636496022,
+    "wof:lastmodified":1690866747,
     "wof:name":"Bentiu",
     "wof:parent_id":1091915999,
     "wof:placetype":"locality",

--- a/data/890/441/679/890441679.geojson
+++ b/data/890/441/679/890441679.geojson
@@ -22,8 +22,14 @@
     "name:ara_x_preferred":[
         "\u0644\u064a\u064a\u0631"
     ],
+    "name:arz_x_preferred":[
+        "\u0644\u064a\u064a\u0631"
+    ],
     "name:ben_x_preferred":[
         "\u09b2\u09c0\u09b0"
+    ],
+    "name:cat_x_preferred":[
+        "Leer"
     ],
     "name:ceb_x_preferred":[
         "Leer"
@@ -32,6 +38,9 @@
         "Leer"
     ],
     "name:dan_x_preferred":[
+        "Leer"
+    ],
+    "name:deu_x_preferred":[
         "Leer"
     ],
     "name:ell_x_preferred":[
@@ -119,7 +128,8 @@
         "\u0644\u06cc\u06cc\u0631 \u060c \u0633\u0627\u0624\u062a\u06be \u0633\u0648\u0688\u0627\u0646"
     ],
     "name:urd_x_variant":[
-        "\u0644\u06cc\u06cc\u0631"
+        "\u0644\u06cc\u06cc\u0631",
+        "\u0644\u06cc\u06cc\u0631 "
     ],
     "name:vie_x_preferred":[
         "Leer"
@@ -132,8 +142,8 @@
     "wof:belongsto":[
         102191573,
         85632657,
-        1091915755,
-        85676963
+        85676963,
+        1091915755
     ],
     "wof:breaches":[],
     "wof:concordances":{
@@ -155,7 +165,7 @@
         }
     ],
     "wof:id":890441679,
-    "wof:lastmodified":1587163142,
+    "wof:lastmodified":1690866747,
     "wof:name":"Ler",
     "wof:parent_id":1091915755,
     "wof:placetype":"locality",

--- a/data/890/452/095/890452095.geojson
+++ b/data/890/452/095/890452095.geojson
@@ -61,6 +61,9 @@
     "name:swe_x_preferred":[
         "Magwi County"
     ],
+    "name:zul_x_preferred":[
+        "Magwi County"
+    ],
     "qs:name":"Magwi County",
     "qs:photos_9r":0,
     "qs:photos_sr":0,
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":890452095,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1690866748,
     "wof:name":"Magwi",
     "wof:parent_id":85676975,
     "wof:placetype":"county",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.

This PR adds new name:* properties from Wikidata. Existing name properties were also cleaned up to remove duplicate name values when present.

This is one PR in a set of PRs needed to close the linked issue.. once approved, I'll merge. Per-language and updated feature counts are listed in https://github.com/whosonfirst-data/whosonfirst-data/issues/2151.