### PR TITLE
ss concordances, placetype local, and more

### DIFF
--- a/data/109/191/339/7/1091913397.geojson
+++ b/data/109/191/339/7/1091913397.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.198362,
-    "geom:area_square_m":2418780242.388289,
+    "geom:area_square_m":2418779653.134022,
     "geom:bbox":"28.76361,9.305861,29.538169,9.75",
     "geom:latitude":9.551165,
     "geom:longitude":29.129865,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.AB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892713,
-    "wof:geomhash":"996a0710a3ae4ea998a423a630426d54",
+    "wof:geomhash":"2d5de0be0b8939e65f0af342817c8699",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913397,
-    "wof:lastmodified":1627522790,
+    "wof:lastmodified":1695886487,
     "wof:name":"Abiemnhom",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/340/1/1091913401.geojson
+++ b/data/109/191/340/1/1091913401.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.915448,
-    "geom:area_square_m":11197639154.08507,
+    "geom:area_square_m":11197638539.934023,
     "geom:bbox":"26.200565,7.895638,27.80384,8.960555",
     "geom:latitude":8.418688,
     "geom:longitude":26.893256,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.NB.AC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892715,
-    "wof:geomhash":"0d25ba01071208eff86fa57d9f91b0d8",
+    "wof:geomhash":"27a8bc7d3aa2dc2c653f1911d46e00f9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913401,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886487,
     "wof:name":"Aweil Centre",
     "wof:parent_id":85676935,
     "wof:placetype":"county",

--- a/data/109/191/340/3/1091913403.geojson
+++ b/data/109/191/340/3/1091913403.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.526988,
-    "geom:area_square_m":6431642528.394932,
+    "geom:area_square_m":6431642440.22763,
     "geom:bbox":"27.181435,8.73026,28.036385,9.628333",
     "geom:latitude":9.24362,
     "geom:longitude":27.613388,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.NB.AE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892716,
-    "wof:geomhash":"fc98656af2837923829f67c96c3c66ed",
+    "wof:geomhash":"d9bfaae9ccf454720b5944999ac12462",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913403,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886487,
     "wof:name":"Aweil East",
     "wof:parent_id":85676935,
     "wof:placetype":"county",

--- a/data/109/191/340/5/1091913405.geojson
+++ b/data/109/191/340/5/1091913405.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.161926,
-    "geom:area_square_m":1979386038.255759,
+    "geom:area_square_m":1979386311.828187,
     "geom:bbox":"27.400945,8.419705,27.998529,8.916414",
     "geom:latitude":8.666813,
     "geom:longitude":27.735483,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.NB.AS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892718,
-    "wof:geomhash":"2faeb0425c2502ce8bb5c793140c08fd",
+    "wof:geomhash":"37d6ac5eebc39e369d60733e04901fef",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913405,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886487,
     "wof:name":"Aweil South",
     "wof:parent_id":85676935,
     "wof:placetype":"county",

--- a/data/109/191/343/1/1091913431.geojson
+++ b/data/109/191/343/1/1091913431.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.827998,
-    "geom:area_square_m":10148304635.117308,
+    "geom:area_square_m":10148305387.528652,
     "geom:bbox":"27.241812,6.739798,28.534497,8.499651",
     "geom:latitude":7.590763,
     "geom:longitude":28.025386,
@@ -91,9 +91,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WB.JR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892719,
-    "wof:geomhash":"c57559c07f5c458d6c617fc8c1afca61",
+    "wof:geomhash":"447ff6b9742116522bd72b00d99fd25c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -103,7 +104,7 @@
         }
     ],
     "wof:id":1091913431,
-    "wof:lastmodified":1627522792,
+    "wof:lastmodified":1695886489,
     "wof:name":"Jur River",
     "wof:parent_id":85676971,
     "wof:placetype":"county",

--- a/data/109/191/346/3/1091913463.geojson
+++ b/data/109/191/346/3/1091913463.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"SS.WR.GE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892721,
     "wof:geomhash":"921dc00fb1564ad19289cc09aa439afb",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913463,
-    "wof:lastmodified":1695886489,
+    "wof:lastmodified":1696023154,
     "wof:name":"Gogrial East",
     "wof:parent_id":85676965,
     "wof:placetype":"county",

--- a/data/109/191/346/3/1091913463.geojson
+++ b/data/109/191/346/3/1091913463.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1091913463,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886489,
     "wof:name":"Gogrial East",
     "wof:parent_id":85676965,
     "wof:placetype":"county",

--- a/data/109/191/349/3/1091913493.geojson
+++ b/data/109/191/349/3/1091913493.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.4718,
-    "geom:area_square_m":5816975831.056983,
+    "geom:area_square_m":5816975831.042645,
     "geom:bbox":"33.006588,3.831618,33.95102,4.908489",
     "geom:latitude":4.358514,
     "geom:longitude":33.448426,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EE.BU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892722,
-    "wof:geomhash":"e20d2c8f4a516c374e4cb778591c33de",
+    "wof:geomhash":"28db475f24070a5a1ea7127a67a4596d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091913493,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886487,
     "wof:name":"Budi",
     "wof:parent_id":85676975,
     "wof:placetype":"county",

--- a/data/109/191/351/7/1091913517.geojson
+++ b/data/109/191/351/7/1091913517.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.471666,
-    "geom:area_square_m":5807175325.350707,
+    "geom:area_square_m":5807175189.859116,
     "geom:bbox":"33.130386,4.781888,33.78479,5.842099",
     "geom:latitude":5.307647,
     "geom:longitude":33.462513,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EE.KN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892724,
-    "wof:geomhash":"e5a853ab473f232559b1e0a971fb33ea",
+    "wof:geomhash":"49f8800e30341dd3591d815a67fdfe22",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913517,
-    "wof:lastmodified":1627522792,
+    "wof:lastmodified":1695886489,
     "wof:name":"Kapoeta North",
     "wof:parent_id":85676975,
     "wof:placetype":"county",

--- a/data/109/191/354/9/1091913549.geojson
+++ b/data/109/191/354/9/1091913549.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.100851,
-    "geom:area_square_m":13469799903.852139,
+    "geom:area_square_m":13469799903.852272,
     "geom:bbox":"30.2850188482,7.69634257094,31.7087870432,8.84926183675",
     "geom:latitude":8.29168,
     "geom:longitude":30.980728,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.AY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892725,
-    "wof:geomhash":"cf09d80bd36d9fecf877137a6349a241",
+    "wof:geomhash":"f8d81265ea72fc5267e633fe93edcc38",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091913549,
-    "wof:lastmodified":1566650390,
+    "wof:lastmodified":1695886434,
     "wof:name":"Ayod",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/358/5/1091913585.geojson
+++ b/data/109/191/358/5/1091913585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.363316,
-    "geom:area_square_m":4441565916.579054,
+    "geom:area_square_m":4441565916.579018,
     "geom:bbox":"29.2792227856,8.29234911383,30.3241034891,8.91599526421",
     "geom:latitude":8.632563,
     "geom:longitude":29.854782,
@@ -120,9 +120,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.KO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892727,
-    "wof:geomhash":"808723792f453030b75942a8e1bd9940",
+    "wof:geomhash":"01187570da4749c98499cbb59fc11db9",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -132,7 +133,7 @@
         }
     ],
     "wof:id":1091913585,
-    "wof:lastmodified":1566650403,
+    "wof:lastmodified":1695886435,
     "wof:name":"Koch",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/360/9/1091913609.geojson
+++ b/data/109/191/360/9/1091913609.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.42664,
-    "geom:area_square_m":5212841470.39854,
+    "geom:area_square_m":5212841582.992719,
     "geom:bbox":"32.785323,8.424278,33.648639,9.380408",
     "geom:latitude":8.835517,
     "geom:longitude":33.162172,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.LU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892729,
-    "wof:geomhash":"293e4b690b876f85da5d6f217ef98a0b",
+    "wof:geomhash":"76394b17bbe943822b8e4f0275b48827",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913609,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886490,
     "wof:name":"Luakpiny/Nasir",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/365/3/1091913653.geojson
+++ b/data/109/191/365/3/1091913653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.293656,
-    "geom:area_square_m":3576168706.100695,
+    "geom:area_square_m":3576169435.520839,
     "geom:bbox":"31.42831,9.672891,32.28944,10.301845",
     "geom:latitude":9.979452,
     "geom:longitude":31.845625,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.FA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892731,
-    "wof:geomhash":"b3f6f1ec0cd98934bce5e684ea536d65",
+    "wof:geomhash":"cde67c33b6e827ee88583d4d644fdd18",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913653,
-    "wof:lastmodified":1627522792,
+    "wof:lastmodified":1695886489,
     "wof:name":"Fashoda",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/368/9/1091913689.geojson
+++ b/data/109/191/368/9/1091913689.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.573626,
-    "geom:area_square_m":6976858776.465246,
+    "geom:area_square_m":6976857939.533344,
     "geom:bbox":"32.104958,9.891056,33.002225,10.850472",
     "geom:latitude":10.38018,
     "geom:longitude":32.568557,
@@ -84,9 +84,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892732,
-    "wof:geomhash":"1ea012f7ef48e28a3b6b04d797b0441e",
+    "wof:geomhash":"30245efaa50fcdca0df79c2de294e746",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091913689,
-    "wof:lastmodified":1636496019,
+    "wof:lastmodified":1695886705,
     "wof:name":"Melut",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/373/3/1091913733.geojson
+++ b/data/109/191/373/3/1091913733.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.28658,
-    "geom:area_square_m":3533731397.9328,
+    "geom:area_square_m":3533731699.309847,
     "geom:bbox":"30.464631,3.736418,31.210975,4.670305",
     "geom:latitude":4.277625,
     "geom:longitude":30.854972,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.BG.LA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892734,
-    "wof:geomhash":"34428192431247765f3620d6a5bc7ef7",
+    "wof:geomhash":"f580af34afcec74e7bada03578c454b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913733,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886490,
     "wof:name":"Lainya",
     "wof:parent_id":85676947,
     "wof:placetype":"county",

--- a/data/109/191/378/1/1091913781.geojson
+++ b/data/109/191/378/1/1091913781.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.479062,
-    "geom:area_square_m":5899125216.44161,
+    "geom:area_square_m":5899125562.501874,
     "geom:bbox":"29.771365,4.609671,30.571246,5.692775",
     "geom:latitude":5.213131,
     "geom:longitude":30.208026,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892735,
-    "wof:geomhash":"8810974346c648db5d06c5d9825c5978",
+    "wof:geomhash":"72c7faa9440f801c09a8ecafefa7587d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913781,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886491,
     "wof:name":"Mundri West",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/382/1/1091913821.geojson
+++ b/data/109/191/382/1/1091913821.geojson
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1091913821,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886488,
     "wof:name":"Canal/Pigi",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/382/1/1091913821.geojson
+++ b/data/109/191/382/1/1091913821.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.KH"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892737,
     "wof:geomhash":"10995c46fd9437d5134ac2795dd7a3af",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091913821,
-    "wof:lastmodified":1695886488,
+    "wof:lastmodified":1696023154,
     "wof:name":"Canal/Pigi",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/386/1/1091913861.geojson
+++ b/data/109/191/386/1/1091913861.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.582091,
-    "geom:area_square_m":7117013471.705196,
+    "geom:area_square_m":7117013444.788924,
     "geom:bbox":"31.490782,8.042621,32.64608,9.092685",
     "geom:latitude":8.583729,
     "geom:longitude":32.118945,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.NY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892739,
-    "wof:geomhash":"9cbaf76f5b017523652f88ef5142213b",
+    "wof:geomhash":"a7e6cc5228a2625e6930a6ae31838e6c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913861,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886491,
     "wof:name":"Nyirol",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/391/3/1091913913.geojson
+++ b/data/109/191/391/3/1091913913.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.25086,
-    "geom:area_square_m":3070789002.452187,
+    "geom:area_square_m":3070789894.187432,
     "geom:bbox":"29.659968,7.69655,30.353472,8.558693",
     "geom:latitude":8.123161,
     "geom:longitude":29.920528,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.MD"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892740,
-    "wof:geomhash":"b432e8a08edc8ccb240aeb372b13a0f8",
+    "wof:geomhash":"0599f20a1ab2bf7f2a65f6c32ff34d7a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913913,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886490,
     "wof:name":"Mayendit",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/395/9/1091913959.geojson
+++ b/data/109/191/395/9/1091913959.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.PJ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892742,
     "wof:geomhash":"1b1af043cbe3078d43124c38816e3142",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091913959,
-    "wof:lastmodified":1695886491,
+    "wof:lastmodified":1696023154,
     "wof:name":"Panyijiar",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/395/9/1091913959.geojson
+++ b/data/109/191/395/9/1091913959.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1091913959,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886491,
     "wof:name":"Panyijiar",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/400/1/1091914001.geojson
+++ b/data/109/191/400/1/1091914001.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.414762,
-    "geom:area_square_m":5059053196.980021,
+    "geom:area_square_m":5059053867.015744,
     "geom:bbox":"30.756117,8.871686,32.079725,9.822458",
     "geom:latitude":9.444131,
     "geom:longitude":31.450719,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.PA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892744,
-    "wof:geomhash":"96dfdf86dea7519564753cd5baf90855",
+    "wof:geomhash":"5377fc44faff8b0b39ccb76a4976d2fe",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914001,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886492,
     "wof:name":"Panyikang",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/404/5/1091914045.geojson
+++ b/data/109/191/404/5/1091914045.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.291884,
-    "geom:area_square_m":3584406823.201662,
+    "geom:area_square_m":3584407071.389581,
     "geom:bbox":"29.570217,6.373381,30.36994,7.115726",
     "geom:latitude":6.718039,
     "geom:longitude":30.01294,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EB.RE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892746,
-    "wof:geomhash":"8430b290b831451e2e0e56082be37975",
+    "wof:geomhash":"a4a59efa01de4eb601e74a6f342dfa28",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914045,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886492,
     "wof:name":"Rumbek East",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/408/9/1091914089.geojson
+++ b/data/109/191/408/9/1091914089.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"SS.EB.CU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892747,
     "wof:geomhash":"aae30dd8f63c80b898390e72662a234a",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914089,
-    "wof:lastmodified":1695886488,
+    "wof:lastmodified":1696023154,
     "wof:name":"Cueibet",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/408/9/1091914089.geojson
+++ b/data/109/191/408/9/1091914089.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1091914089,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886488,
     "wof:name":"Cueibet",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/413/9/1091914139.geojson
+++ b/data/109/191/413/9/1091914139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.363008,
-    "geom:area_square_m":4446610690.146944,
+    "geom:area_square_m":4446610902.318717,
     "geom:bbox":"28.806324,7.486774,29.703512,8.182551",
     "geom:latitude":7.847346,
     "geom:longitude":29.286201,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WR.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892749,
-    "wof:geomhash":"c23fb527468bb19470bcbdfa7651fd05",
+    "wof:geomhash":"434df974c20640db8dd10362e77b55eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914139,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Tonj East",
     "wof:parent_id":85676965,
     "wof:placetype":"county",

--- a/data/109/191/418/9/1091914189.geojson
+++ b/data/109/191/418/9/1091914189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.664187,
-    "geom:area_square_m":8175283162.969456,
+    "geom:area_square_m":8175283842.934271,
     "geom:bbox":"27.248278,4.688948,28.503333,6.517129",
     "geom:latitude":5.458708,
     "geom:longitude":27.89227,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.EZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892756,
-    "wof:geomhash":"1ceb159b9d1e2ada93a4655e13c6f158",
+    "wof:geomhash":"4685cd9cbb30e465c39cccbc9cf20cf5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091914189,
-    "wof:lastmodified":1627522792,
+    "wof:lastmodified":1695886489,
     "wof:name":"Ezo",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/422/1/1091914221.geojson
+++ b/data/109/191/422/1/1091914221.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.609992,
-    "geom:area_square_m":7484979510.839913,
+    "geom:area_square_m":7484979675.159763,
     "geom:bbox":"28.372646,6.389177,29.15491,7.788265",
     "geom:latitude":7.081402,
     "geom:longitude":28.737449,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WR.TS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892758,
-    "wof:geomhash":"ab9d3bc4561ff205440f798d84d32c30",
+    "wof:geomhash":"3be533ae580227ed4791d93247de946e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914221,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Tonj South",
     "wof:parent_id":85676965,
     "wof:placetype":"county",

--- a/data/109/191/426/9/1091914269.geojson
+++ b/data/109/191/426/9/1091914269.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.478232,
-    "geom:area_square_m":5896167182.899759,
+    "geom:area_square_m":5896167182.899757,
     "geom:bbox":"32.0164040884,3.82431860756,33.0495802832,4.94263183398",
     "geom:latitude":4.373575,
     "geom:longitude":32.566402,
@@ -117,9 +117,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EE.TO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892759,
-    "wof:geomhash":"744322298de842e1b33115c4f523a2fa",
+    "wof:geomhash":"cb1a5e2ca173a3147832df4d4018d154",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -129,7 +130,7 @@
         }
     ],
     "wof:id":1091914269,
-    "wof:lastmodified":1566650404,
+    "wof:lastmodified":1695886435,
     "wof:name":"Torit",
     "wof:parent_id":85676975,
     "wof:placetype":"county",

--- a/data/109/191/431/9/1091914319.geojson
+++ b/data/109/191/431/9/1091914319.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.487432,
-    "geom:area_square_m":5980940605.567763,
+    "geom:area_square_m":5980941145.272779,
     "geom:bbox":"30.682315,6.616626,31.789861,7.448196",
     "geom:latitude":7.100532,
     "geom:longitude":31.322258,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892761,
-    "wof:geomhash":"fc673a787f2784256366e71848fc83b1",
+    "wof:geomhash":"2482d45b9b8d810a17ae2fa5e879200e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091914319,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Twic East",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/436/1/1091914361.geojson
+++ b/data/109/191/436/1/1091914361.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.32581,
-    "geom:area_square_m":3977578709.31489,
+    "geom:area_square_m":3977579205.772704,
     "geom:bbox":"27.935314,8.774226,28.808159,9.352981",
     "geom:latitude":9.136581,
     "geom:longitude":28.391097,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WR.TW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892762,
-    "wof:geomhash":"8d3489ff0456e8223d87873a060a9519",
+    "wof:geomhash":"8a3b17f17daa8c1f06fec7908ddd5364",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914361,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Twic",
     "wof:parent_id":85676965,
     "wof:placetype":"county",

--- a/data/109/191/440/9/1091914409.geojson
+++ b/data/109/191/440/9/1091914409.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.39684,
-    "geom:area_square_m":4852058027.711448,
+    "geom:area_square_m":4852058120.829844,
     "geom:bbox":"32.409531,7.979316,33.21886,9.117761",
     "geom:latitude":8.577303,
     "geom:longitude":32.828359,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.UL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892764,
-    "wof:geomhash":"425c0873f32b872b38ee419a3ea0bdb9",
+    "wof:geomhash":"7293a842b9e7beb8e2c239b14ecd89ad",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914409,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Ulang",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/445/5/1091914455.geojson
+++ b/data/109/191/445/5/1091914455.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.627124,
-    "geom:area_square_m":7723722500.944599,
+    "geom:area_square_m":7723722682.597078,
     "geom:bbox":"29.316225,4.560808,30.202271,5.709641",
     "geom:latitude":5.098319,
     "geom:longitude":29.683371,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.MA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892766,
-    "wof:geomhash":"b82cb1bac9d38a573abaf93cf175a9a2",
+    "wof:geomhash":"f1ff874beb636ea2be0e26ea7547e769",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1091914455,
-    "wof:lastmodified":1636496020,
+    "wof:lastmodified":1695886706,
     "wof:name":"Maridi",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/449/5/1091914495.geojson
+++ b/data/109/191/449/5/1091914495.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.960928,
-    "geom:area_square_m":11812408953.904396,
+    "geom:area_square_m":11812408528.300283,
     "geom:bbox":"28.467327,5.674201,29.972406,6.763937",
     "geom:latitude":6.201579,
     "geom:longitude":29.208137,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EB.WU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892767,
-    "wof:geomhash":"ba1873106e844637f72a0d2c4098f635",
+    "wof:geomhash":"3ae59cd03accce77da270dd3a749c2b8",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914495,
-    "wof:lastmodified":1627522796,
+    "wof:lastmodified":1695886494,
     "wof:name":"Wulu",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/453/7/1091914537.geojson
+++ b/data/109/191/453/7/1091914537.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.528839,
-    "geom:area_square_m":6510708121.320014,
+    "geom:area_square_m":6510708665.708218,
     "geom:bbox":"27.767746,4.347136,28.57275,6.275038",
     "geom:latitude":5.317407,
     "geom:longitude":28.207736,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.NZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892769,
-    "wof:geomhash":"4b8d9f09803a562258841c7d3e8e46f9",
+    "wof:geomhash":"49e7d4eb0eaddcba8f3eb52808cb3e5a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914537,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886492,
     "wof:name":"Nzara",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/457/9/1091914579.geojson
+++ b/data/109/191/457/9/1091914579.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.54852,
-    "geom:area_square_m":6763859678.039212,
+    "geom:area_square_m":6763860131.481956,
     "geom:bbox":"29.79678,3.77775,30.931469,4.709768",
     "geom:latitude":4.249008,
     "geom:longitude":30.345504,
@@ -78,9 +78,10 @@
     "wof:concordances":{
         "hasc:id":"SS.BG.YE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892771,
-    "wof:geomhash":"ba66954400091f67f22e12bfb72bfd99",
+    "wof:geomhash":"465a1c9e3f278821464a679a7485f291",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -90,7 +91,7 @@
         }
     ],
     "wof:id":1091914579,
-    "wof:lastmodified":1636496020,
+    "wof:lastmodified":1695886706,
     "wof:name":"Yei",
     "wof:parent_id":85676947,
     "wof:placetype":"county",

--- a/data/109/191/458/1/1091914581.geojson
+++ b/data/109/191/458/1/1091914581.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.142453,
-    "geom:area_square_m":14036578208.695904,
+    "geom:area_square_m":14036578087.950125,
     "geom:bbox":"31.30998,5.848611,32.627664,7.094629",
     "geom:latitude":6.464956,
     "geom:longitude":32.005054,
@@ -67,9 +67,10 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.BS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892772,
-    "wof:geomhash":"bdfbcfe7f8c5f162b951f73b419913b8",
+    "wof:geomhash":"0ca8c0c0c7c668b4702d324f63216d50",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091914581,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886488,
     "wof:name":"Bor South",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/458/3/1091914583.geojson
+++ b/data/109/191/458/3/1091914583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.455015,
-    "geom:area_square_m":5586815869.434744,
+    "geom:area_square_m":5586815507.304132,
     "geom:bbox":"30.318063,6.333336,31.374661,7.219234",
     "geom:latitude":6.793572,
     "geom:longitude":30.801343,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EB.YE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892774,
-    "wof:geomhash":"399c48278d7f9aa3d23bffa39035d648",
+    "wof:geomhash":"138eda772c060d85394abcac9c1b02af",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914583,
-    "wof:lastmodified":1627522796,
+    "wof:lastmodified":1695886494,
     "wof:name":"Yirol East",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/458/5/1091914585.geojson
+++ b/data/109/191/458/5/1091914585.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.397123,
-    "geom:area_square_m":4879938321.52781,
+    "geom:area_square_m":4879938581.40591,
     "geom:bbox":"29.952822,6.079704,31.016212,6.691766",
     "geom:latitude":6.394939,
     "geom:longitude":30.487358,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EB.YW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892775,
-    "wof:geomhash":"7f014f111e0ac172032aceec75744f19",
+    "wof:geomhash":"8c7ab057e47d220da7ee7ff735d5572b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914585,
-    "wof:lastmodified":1627522796,
+    "wof:lastmodified":1695886494,
     "wof:name":"Yirol West",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/465/3/1091914653.geojson
+++ b/data/109/191/465/3/1091914653.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.527212,
-    "geom:area_square_m":6432683406.455519,
+    "geom:area_square_m":6432683211.189367,
     "geom:bbox":"26.145035,8.917766,27.381426,9.866408",
     "geom:latitude":9.336929,
     "geom:longitude":26.726882,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.NB.AN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892778,
-    "wof:geomhash":"aadfa9a92f9c97e78d7131366f0258bf",
+    "wof:geomhash":"2c5898fb517d07bf21810bb8d7b66c5d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914653,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886488,
     "wof:name":"Aweil North",
     "wof:parent_id":85676935,
     "wof:placetype":"county",

--- a/data/109/191/470/1/1091914701.geojson
+++ b/data/109/191/470/1/1091914701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.786012,
-    "geom:area_square_m":9680490062.710186,
+    "geom:area_square_m":9680489536.088493,
     "geom:bbox":"28.593124,4.340702,29.468781,5.776422",
     "geom:latitude":5.102551,
     "geom:longitude":29.062173,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.IB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892780,
-    "wof:geomhash":"c73d00930550fff06eb1df42967e52b0",
+    "wof:geomhash":"fb17e5c7044cb21ee3845e031d4f1cd5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914701,
-    "wof:lastmodified":1627522792,
+    "wof:lastmodified":1695886489,
     "wof:name":"Ibba",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/475/3/1091914753.geojson
+++ b/data/109/191/475/3/1091914753.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.285701,
-    "geom:area_square_m":3524011004.675015,
+    "geom:area_square_m":3524011004.675174,
     "geom:bbox":"32.7822085827,3.749066,33.5967814652,4.41616651393",
     "geom:latitude":4.028592,
     "geom:longitude":33.131466,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EE.IK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892781,
-    "wof:geomhash":"4509f7e4ebfad7daba193113b0c93654",
+    "wof:geomhash":"456965e3058df8fa20abcbf162e8e058",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091914753,
-    "wof:lastmodified":1566650404,
+    "wof:lastmodified":1695886435,
     "wof:name":"Ikotos",
     "wof:parent_id":85676975,
     "wof:placetype":"county",

--- a/data/109/191/479/1/1091914791.geojson
+++ b/data/109/191/479/1/1091914791.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.153238,
-    "geom:area_square_m":26515891154.872513,
+    "geom:area_square_m":26515892592.02779,
     "geom:bbox":"33.626564,4.178446,35.948997,6.001865",
     "geom:latitude":5.181214,
     "geom:longitude":34.595849,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EE.KE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892783,
-    "wof:geomhash":"a3cd42ce884c5ff5eaa6902cc6694fa8",
+    "wof:geomhash":"c1c0ce479dc4dd59b17ed6cb1a9d1ece",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914791,
-    "wof:lastmodified":1627522792,
+    "wof:lastmodified":1695886489,
     "wof:name":"Kapoeta East",
     "wof:parent_id":85676975,
     "wof:placetype":"county",

--- a/data/109/191/484/7/1091914847.geojson
+++ b/data/109/191/484/7/1091914847.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.978186,
-    "geom:area_square_m":11910494474.007217,
+    "geom:area_square_m":11910495718.102188,
     "geom:bbox":"32.955949,9.339717,33.999659,10.723733",
     "geom:latitude":10.027952,
     "geom:longitude":33.459733,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.MB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892785,
-    "wof:geomhash":"cc0f60223e36e3c92e0f54d364715c15",
+    "wof:geomhash":"e5102f468d81fa63991452bd9f887ddc",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914847,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886491,
     "wof:name":"Maban",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/489/5/1091914895.geojson
+++ b/data/109/191/489/5/1091914895.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.309424,
-    "geom:area_square_m":3781625911.191136,
+    "geom:area_square_m":3781626002.244036,
     "geom:bbox":"33.464135,8.367628,34.145517,9.211037",
     "geom:latitude":8.741743,
     "geom:longitude":33.863289,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.MW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892786,
-    "wof:geomhash":"c47e3c5e088a984a70d254d38e04ebb6",
+    "wof:geomhash":"64e68ce255595875add1f9da1b1a095d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091914895,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886491,
     "wof:name":"Maiwut",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/492/7/1091914927.geojson
+++ b/data/109/191/492/7/1091914927.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.552776,
-    "geom:area_square_m":6706220235.056769,
+    "geom:area_square_m":6706220044.128461,
     "geom:bbox":"31.787144,10.122358,32.789852,11.951051",
     "geom:latitude":11.132624,
     "geom:longitude":32.368586,
@@ -72,9 +72,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.MN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892788,
-    "wof:geomhash":"b39fb8f40f403d5436f82d5754d7af2c",
+    "wof:geomhash":"bfc1a23330f9500ef655209869444c0b",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -84,7 +85,7 @@
         }
     ],
     "wof:id":1091914927,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886491,
     "wof:name":"Manyo",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/497/5/1091914975.geojson
+++ b/data/109/191/497/5/1091914975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.106759,
-    "geom:area_square_m":1317289162.414373,
+    "geom:area_square_m":1317288968.222774,
     "geom:bbox":"30.556342,3.488987,31.10145,3.945105",
     "geom:latitude":3.740053,
     "geom:longitude":30.833774,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.BG.MO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892790,
-    "wof:geomhash":"3f1634b3dde0593a38a922eb931e8179",
+    "wof:geomhash":"c8716b300d18729de76ec9318bf6b325",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091914975,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886492,
     "wof:name":"Morobo",
     "wof:parent_id":85676947,
     "wof:placetype":"county",

--- a/data/109/191/502/1/1091915021.geojson
+++ b/data/109/191/502/1/1091915021.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.740446,
-    "geom:area_square_m":9021682586.680052,
+    "geom:area_square_m":9021682439.595528,
     "geom:bbox":"29.535406,9.383153,30.843851,10.288068",
     "geom:latitude":9.815442,
     "geom:longitude":30.118467,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.PR"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892791,
-    "wof:geomhash":"4220a7109f9aee3ceff8068404c98e73",
+    "wof:geomhash":"605011b31e96fc2d79d2cd3201b9d4bf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915021,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886492,
     "wof:name":"Pariang",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/505/9/1091915059.geojson
+++ b/data/109/191/505/9/1091915059.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.693326,
-    "geom:area_square_m":33095502598.917496,
+    "geom:area_square_m":33095502498.344833,
     "geom:bbox":"32.389713,5.720021,35.022058,7.399072",
     "geom:latitude":6.396698,
     "geom:longitude":33.571121,
@@ -129,9 +129,10 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.PI"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892793,
-    "wof:geomhash":"937f0beb1af51c0ebd61e7c4fc6682d9",
+    "wof:geomhash":"e525be6b36abb4757f61422ba1a65699",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -141,7 +142,7 @@
         }
     ],
     "wof:id":1091915059,
-    "wof:lastmodified":1636496018,
+    "wof:lastmodified":1695886705,
     "wof:name":"Pibor",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/510/1/1091915101.geojson
+++ b/data/109/191/510/1/1091915101.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.676916,
-    "geom:area_square_m":8305709422.260561,
+    "geom:area_square_m":8305709422.260295,
     "geom:bbox":"33.2119428791,6.67116958964,34.54339,7.736792",
     "geom:latitude":7.11293,
     "geom:longitude":33.812947,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.PO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892794,
-    "wof:geomhash":"baea535e0d987ac8f76dd77fe8789fa5",
+    "wof:geomhash":"18af3b78e364829a699161993b5d4d52",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091915101,
-    "wof:lastmodified":1566650397,
+    "wof:lastmodified":1695886434,
     "wof:name":"Pochalla",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/515/3/1091915153.geojson
+++ b/data/109/191/515/3/1091915153.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.125425,
-    "geom:area_square_m":74857188185.144272,
+    "geom:area_square_m":74857188185.145798,
     "geom:bbox":"23.440849,6.64783429418,26.9278545437,10.43898875",
     "geom:latitude":8.724488,
     "geom:longitude":25.338186,
@@ -162,9 +162,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WB.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892796,
-    "wof:geomhash":"0c5eda7727c100be917f04d3db09500c",
+    "wof:geomhash":"02570e2c8cb3f610c8f6afd560902f0d",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -174,7 +175,7 @@
         }
     ],
     "wof:id":1091915153,
-    "wof:lastmodified":1566650410,
+    "wof:lastmodified":1695886436,
     "wof:name":"Raga",
     "wof:parent_id":85676971,
     "wof:placetype":"county",

--- a/data/109/191/519/5/1091915195.geojson
+++ b/data/109/191/519/5/1091915195.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.843948,
-    "geom:area_square_m":10230810061.958647,
+    "geom:area_square_m":10230810858.261375,
     "geom:bbox":"32.472808,10.347851,33.354392,12.236389",
     "geom:latitude":11.359003,
     "geom:longitude":32.959236,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.RE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892798,
-    "wof:geomhash":"be4ab9ca64047c61927dded2da345649",
+    "wof:geomhash":"984f9673686d01933f7e6eb1d0494b93",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091915195,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886492,
     "wof:name":"Renk",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/524/3/1091915243.geojson
+++ b/data/109/191/524/3/1091915243.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.021343,
-    "geom:area_square_m":12558635103.771423,
+    "geom:area_square_m":12558635103.771786,
     "geom:bbox":"26.284445,5.34650288008,27.9664177231,6.71899970878",
     "geom:latitude":6.04553,
     "geom:longitude":27.142079,
@@ -81,9 +81,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.TA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892799,
-    "wof:geomhash":"f8fc07883da25bd2949e31409b87df25",
+    "wof:geomhash":"33a51e41a27a1433c2290bdfab91676e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -93,7 +94,7 @@
         }
     ],
     "wof:id":1091915243,
-    "wof:lastmodified":1566650409,
+    "wof:lastmodified":1695886436,
     "wof:name":"Tambura",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/528/5/1091915285.geojson
+++ b/data/109/191/528/5/1091915285.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.739585,
-    "geom:area_square_m":9060380449.346203,
+    "geom:area_square_m":9060380352.217327,
     "geom:bbox":"32.163234,7.191459,33.529629,8.435633",
     "geom:latitude":7.799643,
     "geom:longitude":32.85412,
@@ -133,9 +133,10 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.AK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892801,
-    "wof:geomhash":"c895448163bc324b0c5ee62896878247",
+    "wof:geomhash":"542bc855cbe753260dc1904aa732e952",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -145,7 +146,7 @@
         }
     ],
     "wof:id":1091915285,
-    "wof:lastmodified":1636496019,
+    "wof:lastmodified":1695886705,
     "wof:name":"Akobo",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/532/9/1091915329.geojson
+++ b/data/109/191/532/9/1091915329.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.413799,
-    "geom:area_square_m":5054659058.392956,
+    "geom:area_square_m":5054658749.433007,
     "geom:bbox":"26.134083,8.601897,27.431274,9.20839",
     "geom:latitude":8.930831,
     "geom:longitude":26.718769,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.NB.AW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892802,
-    "wof:geomhash":"f897f21646310b99770ba25bc8e9227f",
+    "wof:geomhash":"e54b9707b9b4eb408c570245e5c187cf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915329,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886488,
     "wof:name":"Aweil West",
     "wof:parent_id":85676935,
     "wof:placetype":"county",

--- a/data/109/191/536/9/1091915369.geojson
+++ b/data/109/191/536/9/1091915369.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.37194,
-    "geom:area_square_m":4572613654.283226,
+    "geom:area_square_m":4572614100.435442,
     "geom:bbox":"30.624839,5.865737,31.693703,6.505904",
     "geom:latitude":6.151133,
     "geom:longitude":31.226856,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EB.AW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892804,
-    "wof:geomhash":"00077504b52e78655f4fdd562e24408a",
+    "wof:geomhash":"a12b366b6373a559fa332dc2a86b0844",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091915369,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886488,
     "wof:name":"Awerial",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/540/7/1091915407.geojson
+++ b/data/109/191/540/7/1091915407.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.099032,
-    "geom:area_square_m":1220663025.957003,
+    "geom:area_square_m":1220662904.563685,
     "geom:bbox":"33.443826,4.219598,33.917882,4.871075",
     "geom:latitude":4.564939,
     "geom:longitude":33.680312,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EE.KS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892805,
-    "wof:geomhash":"b81c9f0adf13e6ac60caf583b5ebba50",
+    "wof:geomhash":"9c4ae6886a19f6d674fd185fd98daeb6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915407,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886491,
     "wof:name":"Kapoeta South",
     "wof:parent_id":85676975,
     "wof:placetype":"county",

--- a/data/109/191/544/9/1091915449.geojson
+++ b/data/109/191/544/9/1091915449.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.56407,
-    "geom:area_square_m":6913256328.377392,
+    "geom:area_square_m":6913256046.267497,
     "geom:bbox":"30.507679,7.282012,31.757289,8.03796",
     "geom:latitude":7.617652,
     "geom:longitude":31.185652,
@@ -76,9 +76,10 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.DU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892807,
-    "wof:geomhash":"6e0f3c6318c30394e02a31d2a59b7fb9",
+    "wof:geomhash":"48d371f04eb8d0f2cf415ed37085dbcf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -88,7 +89,7 @@
         }
     ],
     "wof:id":1091915449,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886488,
     "wof:name":"Duk",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/546/3/1091915463.geojson
+++ b/data/109/191/546/3/1091915463.geojson
@@ -82,7 +82,7 @@
         }
     ],
     "wof:id":1091915463,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886435,
     "wof:name":"Fangak",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/546/3/1091915463.geojson
+++ b/data/109/191/546/3/1091915463.geojson
@@ -70,6 +70,7 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.OF"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892808,
     "wof:geomhash":"aa7553f172c85b93c0d55dfd16cdd750",
@@ -82,7 +83,7 @@
         }
     ],
     "wof:id":1091915463,
-    "wof:lastmodified":1695886435,
+    "wof:lastmodified":1696023152,
     "wof:name":"Fangak",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/550/3/1091915503.geojson
+++ b/data/109/191/550/3/1091915503.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.960299,
-    "geom:area_square_m":11711606630.614159,
+    "geom:area_square_m":11711605115.830009,
     "geom:bbox":"31.707267,8.716187,32.996497,10.099195",
     "geom:latitude":9.490906,
     "geom:longitude":32.402248,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.BA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892810,
-    "wof:geomhash":"21849ac10ec5bfbd132f6a89f8cb4dae",
+    "wof:geomhash":"b8dd56350875f708e1aa00d26c7458b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915503,
-    "wof:lastmodified":1627522791,
+    "wof:lastmodified":1695886488,
     "wof:name":"Baliet",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/555/1/1091915551.geojson
+++ b/data/109/191/555/1/1091915551.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.361973,
-    "geom:area_square_m":4425868429.732261,
+    "geom:area_square_m":4425869109.391882,
     "geom:bbox":"27.862888,8.023033,28.459834,9.127116",
     "geom:latitude":8.567798,
     "geom:longitude":28.11035,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WR.GW"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892812,
-    "wof:geomhash":"7b6128eb889763b240659c7a2c6c5373",
+    "wof:geomhash":"0f532a498d8754d1859de8c4540044a5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915551,
-    "wof:lastmodified":1627522792,
+    "wof:lastmodified":1695886490,
     "wof:name":"Gogrial West",
     "wof:parent_id":85676965,
     "wof:placetype":"county",

--- a/data/109/191/558/3/1091915583.geojson
+++ b/data/109/191/558/3/1091915583.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.282869,
-    "geom:area_square_m":3452748680.650735,
+    "geom:area_square_m":3452748345.161131,
     "geom:bbox":"29.809985,8.842962,30.391163,9.551198",
     "geom:latitude":9.197213,
     "geom:longitude":30.07492,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.GU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892813,
-    "wof:geomhash":"8c6bd2f455c2ea92f35e117a43f721a7",
+    "wof:geomhash":"8f8de423708fc72c48f2334a3cde1ed6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915583,
-    "wof:lastmodified":1627522792,
+    "wof:lastmodified":1695886490,
     "wof:name":"Guit",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/563/3/1091915633.geojson
+++ b/data/109/191/563/3/1091915633.geojson
@@ -81,7 +81,7 @@
         }
     ],
     "wof:id":1091915633,
-    "wof:lastmodified":1694492409,
+    "wof:lastmodified":1695886435,
     "wof:name":"Lafon",
     "wof:parent_id":85676975,
     "wof:placetype":"county",

--- a/data/109/191/563/3/1091915633.geojson
+++ b/data/109/191/563/3/1091915633.geojson
@@ -69,6 +69,7 @@
     "wof:concordances":{
         "hasc:id":"SS.EE.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892815,
     "wof:geomhash":"5395314f81043f191bb80aa73c7bd748",
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091915633,
-    "wof:lastmodified":1695886435,
+    "wof:lastmodified":1696023152,
     "wof:name":"Lafon",
     "wof:parent_id":85676975,
     "wof:placetype":"county",

--- a/data/109/191/567/7/1091915677.geojson
+++ b/data/109/191/567/7/1091915677.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.49241,
-    "geom:area_square_m":18391114689.347813,
+    "geom:area_square_m":18391114689.34856,
     "geom:bbox":"30.5146880593,3.95984043011,32.1698876094,5.46041741784",
     "geom:latitude":4.717428,
     "geom:longitude":31.482631,
@@ -373,9 +373,10 @@
     "wof:concordances":{
         "hasc:id":"SS.BG.JU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892816,
-    "wof:geomhash":"b81087fb7f8ee659d92254c0cc7f9367",
+    "wof:geomhash":"43bd1d11889a7fd331faef42b5cbfd59",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -385,7 +386,7 @@
         }
     ],
     "wof:id":1091915677,
-    "wof:lastmodified":1566650389,
+    "wof:lastmodified":1695886434,
     "wof:name":"Juba",
     "wof:parent_id":85676947,
     "wof:placetype":"county",

--- a/data/109/191/571/5/1091915715.geojson
+++ b/data/109/191/571/5/1091915715.geojson
@@ -67,6 +67,7 @@
     "wof:concordances":{
         "hasc:id":"SS.BG.KK"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892818,
     "wof:geomhash":"c1b903a8eeb316833c1a7be94bc73aaa",
@@ -79,7 +80,7 @@
         }
     ],
     "wof:id":1091915715,
-    "wof:lastmodified":1695886490,
+    "wof:lastmodified":1696023154,
     "wof:name":"Kajo-keji",
     "wof:parent_id":85676947,
     "wof:placetype":"county",

--- a/data/109/191/571/5/1091915715.geojson
+++ b/data/109/191/571/5/1091915715.geojson
@@ -79,7 +79,7 @@
         }
     ],
     "wof:id":1091915715,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886490,
     "wof:name":"Kajo-keji",
     "wof:parent_id":85676947,
     "wof:placetype":"county",

--- a/data/109/191/575/5/1091915755.geojson
+++ b/data/109/191/575/5/1091915755.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.133176,
-    "geom:area_square_m":1630014885.020323,
+    "geom:area_square_m":1630014885.020365,
     "geom:bbox":"30.0373598701,7.89580518335,30.4664505457,8.48173741635",
     "geom:latitude":8.174471,
     "geom:longitude":30.228322,
@@ -168,9 +168,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.LE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892820,
-    "wof:geomhash":"fed03ccc4dfd76631f98530e82d6970a",
+    "wof:geomhash":"d43e0fb30198dd3c845947a76874e2b1",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1091915755,
-    "wof:lastmodified":1566650399,
+    "wof:lastmodified":1695886435,
     "wof:name":"Leer",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/580/1/1091915801.geojson
+++ b/data/109/191/580/1/1091915801.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.569061,
-    "geom:area_square_m":6944892353.986838,
+    "geom:area_square_m":6944891880.470414,
     "geom:bbox":"32.916248,8.838717,34.131594,9.771509",
     "geom:latitude":9.255755,
     "geom:longitude":33.526279,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.LO"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892821,
-    "wof:geomhash":"f418b290204784cd09c0eff41fa9fee8",
+    "wof:geomhash":"f2c45b25d72751cf1d60653a9ed31dce",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915801,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886491,
     "wof:name":"Longochuk",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/584/5/1091915845.geojson
+++ b/data/109/191/584/5/1091915845.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061174,
-    "geom:area_square_m":745711615.370699,
+    "geom:area_square_m":745711496.753948,
     "geom:bbox":"31.370134,9.44983,31.867457,9.891365",
     "geom:latitude":9.656777,
     "geom:longitude":31.644925,
@@ -171,9 +171,10 @@
     "wof:concordances":{
         "hasc:id":"SS.UN.ML"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892823,
-    "wof:geomhash":"37b7b1c6aef9e2544816631df9e7a655",
+    "wof:geomhash":"13342adac00d3e614482ef74280773a6",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -183,7 +184,7 @@
         }
     ],
     "wof:id":1091915845,
-    "wof:lastmodified":1636496020,
+    "wof:lastmodified":1695886706,
     "wof:name":"Malakal",
     "wof:parent_id":85676953,
     "wof:placetype":"county",

--- a/data/109/191/587/9/1091915879.geojson
+++ b/data/109/191/587/9/1091915879.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.35141,
-    "geom:area_square_m":4290621953.595342,
+    "geom:area_square_m":4290621723.231829,
     "geom:bbox":"28.701851,8.692918,29.609501,9.453466",
     "geom:latitude":9.093551,
     "geom:longitude":29.21647,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.MM"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892824,
-    "wof:geomhash":"37bb050803bf2380582e01f10990d7f7",
+    "wof:geomhash":"b869df1b01d79b3502bbbcb13bd165e3",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915879,
-    "wof:lastmodified":1627522793,
+    "wof:lastmodified":1695886491,
     "wof:name":"Mayom",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/590/5/1091915905.geojson
+++ b/data/109/191/590/5/1091915905.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.414409,
-    "geom:area_square_m":5102227484.272037,
+    "geom:area_square_m":5102227982.820153,
     "geom:bbox":"30.346187,4.801292,31.017784,5.801367",
     "geom:latitude":5.308117,
     "geom:longitude":30.682003,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.ME"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892826,
-    "wof:geomhash":"5bb521de7953c9ce09da4c6a6f53efca",
+    "wof:geomhash":"9841881fdcc7cd88053b9f32592f296e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915905,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886492,
     "wof:name":"Mundri East",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/594/5/1091915945.geojson
+++ b/data/109/191/594/5/1091915945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.467477,
-    "geom:area_square_m":5749601798.42528,
+    "geom:area_square_m":5749601802.869932,
     "geom:bbox":"29.569125,5.539795,30.592125,6.365992",
     "geom:latitude":5.91856,
     "geom:longitude":30.031262,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.MV"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892829,
-    "wof:geomhash":"8dce92f79ea3de662c2ba26bb1ebd175",
+    "wof:geomhash":"611e3d9e1355e2e0e57842dd82ba8735",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915945,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886492,
     "wof:name":"Mvolo",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/598/5/1091915985.geojson
+++ b/data/109/191/598/5/1091915985.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.755762,
-    "geom:area_square_m":9285530342.659355,
+    "geom:area_square_m":9285530642.565638,
     "geom:bbox":"27.068824,6.014829,28.503333,6.798119",
     "geom:latitude":6.472376,
     "geom:longitude":27.737834,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892830,
-    "wof:geomhash":"59fd4a1ed39f2b91caf1f3e67a85c321",
+    "wof:geomhash":"9152e28ee2465d6609349d58e926eb4c",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091915985,
-    "wof:lastmodified":1627522794,
+    "wof:lastmodified":1695886492,
     "wof:name":"Nagero",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/109/191/599/9/1091915999.geojson
+++ b/data/109/191/599/9/1091915999.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.293276,
-    "geom:area_square_m":3579048844.07327,
+    "geom:area_square_m":3579049254.622573,
     "geom:bbox":"29.344534,8.859855,29.917858,9.747052",
     "geom:latitude":9.268299,
     "geom:longitude":29.636143,
@@ -75,9 +75,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WH.RU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892832,
-    "wof:geomhash":"9d76eebd8945ff5a3b8b0fee5a5ff2b0",
+    "wof:geomhash":"eb2de9579ec2cacdd6b428f7406cfc19",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -87,7 +88,7 @@
         }
     ],
     "wof:id":1091915999,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Rubkona",
     "wof:parent_id":85676963,
     "wof:placetype":"county",

--- a/data/109/191/601/3/1091916013.geojson
+++ b/data/109/191/601/3/1091916013.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.31536,
-    "geom:area_square_m":3870261235.182396,
+    "geom:area_square_m":3870261926.715742,
     "geom:bbox":"29.376177,6.667385,30.2257,7.307292",
     "geom:latitude":7.017994,
     "geom:longitude":29.783416,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EB.RC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892834,
-    "wof:geomhash":"f9a526697ec36fe3d95a3b24ee536bd5",
+    "wof:geomhash":"01db6c1c446dd80ec1eaf0e6e56106f2",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091916013,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Rumbek Centre",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/606/1/1091916061.geojson
+++ b/data/109/191/606/1/1091916061.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.334823,
-    "geom:area_square_m":4104493701.652977,
+    "geom:area_square_m":4104492485.722063,
     "geom:bbox":"29.174083,7.248536,30.142435,7.833143",
     "geom:latitude":7.524708,
     "geom:longitude":29.703185,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.EB.RN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892835,
-    "wof:geomhash":"4cf4a6c729a472f39514399cffd72b72",
+    "wof:geomhash":"3b04ccc6464195de9eda7ddfba6208a4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091916061,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Rumbek North",
     "wof:parent_id":85676939,
     "wof:placetype":"county",

--- a/data/109/191/607/5/1091916075.geojson
+++ b/data/109/191/607/5/1091916075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.8712,
-    "geom:area_square_m":10719931956.762634,
+    "geom:area_square_m":10719930261.171608,
     "geom:bbox":"30.309592,5.126752,32.114383,6.248087",
     "geom:latitude":5.661652,
     "geom:longitude":31.326758,
@@ -69,9 +69,10 @@
     "wof:concordances":{
         "hasc:id":"SS.BG.TE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892837,
-    "wof:geomhash":"a3b2a9a2abb010214866436f50ae45c5",
+    "wof:geomhash":"a9fc79be39c92c5dbd42997c75e2aec0",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -81,7 +82,7 @@
         }
     ],
     "wof:id":1091916075,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886493,
     "wof:name":"Terekeka",
     "wof:parent_id":85676947,
     "wof:placetype":"county",

--- a/data/109/191/612/3/1091916123.geojson
+++ b/data/109/191/612/3/1091916123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.91791,
-    "geom:area_square_m":11232685641.17201,
+    "geom:area_square_m":11232684730.836718,
     "geom:bbox":"28.1689,7.584579,29.677431,8.9061",
     "geom:latitude":8.244936,
     "geom:longitude":28.914865,
@@ -66,9 +66,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WR.TN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892838,
-    "wof:geomhash":"7cf63b70bbb304972bfa221085b39edf",
+    "wof:geomhash":"4af0b6607374353bfb92ec834ce16745",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091916123,
-    "wof:lastmodified":1627522795,
+    "wof:lastmodified":1695886494,
     "wof:name":"Tonj North",
     "wof:parent_id":85676965,
     "wof:placetype":"county",

--- a/data/109/191/616/7/1091916167.geojson
+++ b/data/109/191/616/7/1091916167.geojson
@@ -78,7 +78,7 @@
         }
     ],
     "wof:id":1091916167,
-    "wof:lastmodified":1694492794,
+    "wof:lastmodified":1695886494,
     "wof:name":"Uror",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/616/7/1091916167.geojson
+++ b/data/109/191/616/7/1091916167.geojson
@@ -66,6 +66,7 @@
     "wof:concordances":{
         "hasc:id":"SS.JG.WU"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892840,
     "wof:geomhash":"f4c7800c154398842ff2f64262f405ac",
@@ -78,7 +79,7 @@
         }
     ],
     "wof:id":1091916167,
-    "wof:lastmodified":1695886494,
+    "wof:lastmodified":1696023154,
     "wof:name":"Uror",
     "wof:parent_id":85676957,
     "wof:placetype":"county",

--- a/data/109/191/618/7/1091916187.geojson
+++ b/data/109/191/618/7/1091916187.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":1.568702,
-    "geom:area_square_m":19240286423.879925,
+    "geom:area_square_m":19240285707.997765,
     "geom:bbox":"26.447447,6.650103,28.092881,8.146731",
     "geom:latitude":7.28668,
     "geom:longitude":27.296926,
@@ -93,9 +93,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WB.WA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892841,
-    "wof:geomhash":"e349e5df90ed9f1627886378c720aee0",
+    "wof:geomhash":"6db655f6e51018f3f4dd43ee935b06b5",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -105,7 +106,7 @@
         }
     ],
     "wof:id":1091916187,
-    "wof:lastmodified":1636496019,
+    "wof:lastmodified":1695886705,
     "wof:name":"Wau",
     "wof:parent_id":85676971,
     "wof:placetype":"county",

--- a/data/109/191/623/3/1091916233.geojson
+++ b/data/109/191/623/3/1091916233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.717756,
-    "geom:area_square_m":8839378043.327803,
+    "geom:area_square_m":8839378244.803801,
     "geom:bbox":"28.17764,4.28069,28.945119,6.075147",
     "geom:latitude":5.127584,
     "geom:longitude":28.547118,
@@ -138,9 +138,10 @@
     "wof:concordances":{
         "hasc:id":"SS.WE.YA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1473892843,
-    "wof:geomhash":"6c245dc912254cd8b077eabbe8eb3c86",
+    "wof:geomhash":"e59f4190d0d56f34602a1ed4f8a3e017",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -150,7 +151,7 @@
         }
     ],
     "wof:id":1091916233,
-    "wof:lastmodified":1636496019,
+    "wof:lastmodified":1695886706,
     "wof:name":"Yambio",
     "wof:parent_id":85676945,
     "wof:placetype":"county",

--- a/data/856/326/57/85632657.geojson
+++ b/data/856/326/57/85632657.geojson
@@ -954,6 +954,7 @@
         "gn:id":7909807,
         "gp:id":56558055,
         "hasc:id":"SS",
+        "iso:code":"SS",
         "itu:id":"SSD",
         "m49:code":"728",
         "marc:id":"sd",
@@ -964,6 +965,7 @@
         "wd:id":"Q958",
         "wk:page":"South Sudan"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:country_alpha3":"SSD",
     "wof:geom_alt":[
@@ -986,7 +988,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639600,
+    "wof:lastmodified":1695881262,
     "wof:name":"South Sudan",
     "wof:parent_id":102191573,
     "wof:placetype":"country",

--- a/data/856/769/35/85676935.geojson
+++ b/data/856/769/35/85676935.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":2.545373,
-    "geom:area_square_m":31096010185.583183,
+    "geom:area_square_m":31096009252.611881,
     "geom:bbox":"26.134083,7.895638,28.036385,9.866408",
     "geom:latitude":8.878715,
     "geom:longitude":27.033103,
@@ -303,16 +303,18 @@
         "gn:id":408665,
         "gp:id":20069897,
         "hasc:id":"SS.NB",
+        "iso:code":"SS-BN",
         "iso:id":"SS-BN",
         "qs_pg:id":888131,
         "wd:id":"Q491111",
         "wk:page":"Northern Bahr el Ghazal"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"48c7659b8d777ad3a72232e7663cc41c",
+    "wof:geomhash":"697c694b074acff002d9747feb718e6a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866737,
+    "wof:lastmodified":1695884535,
     "wof:name":"North Bahr-al-Ghazal",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/39/85676939.geojson
+++ b/data/856/769/39/85676939.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.521825,
-    "geom:area_square_m":43254868013.90197,
+    "geom:area_square_m":43254867320.889717,
     "geom:bbox":"28.467327,5.674201,31.693703,7.833143",
     "geom:latitude":6.634783,
     "geom:longitude":29.938808,
@@ -302,17 +302,19 @@
         "gn:id":408647,
         "gp:id":20069896,
         "hasc:id":"SS.EB",
+        "iso:code":"SS-LK",
         "iso:id":"SS-LK",
         "qs_pg:id":1085606,
         "unlc:id":"SS-LK",
         "wd:id":"Q491096",
         "wk:page":"Lakes (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b532a83626fd0f526fb5e171daec2ba7",
+    "wof:geomhash":"e01d82cf31149ad8682b5a85067bce6a",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866738,
+    "wof:lastmodified":1695884837,
     "wof:name":"Lakes",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/45/85676945.geojson
+++ b/data/856/769/45/85676945.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.46197,
-    "geom:area_square_m":79524701836.842758,
+    "geom:area_square_m":79524703507.866043,
     "geom:bbox":"26.284445,4.28069,31.017784,6.798119",
     "geom:latitude":5.548775,
     "geom:longitude":28.675645,
@@ -301,17 +301,19 @@
         "gn:id":408656,
         "gp:id":20069900,
         "hasc:id":"SS.WE",
+        "iso:code":"SS-EW",
         "iso:id":"SS-EW",
         "qs_pg:id":1180243,
         "unlc:id":"SS-EW",
         "wd:id":"Q319979",
         "wk:page":"Western Equatoria"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"cf1e93214299f4fb11b965c9533e42cb",
+    "wof:geomhash":"982e25a0e3cff71ddd5211e1442d1316",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -326,7 +328,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866737,
+    "wof:lastmodified":1695884536,
     "wof:name":"West Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/47/85676947.geojson
+++ b/data/856/769/47/85676947.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.510738,
-    "geom:area_square_m":43258232533.474373,
+    "geom:area_square_m":43258231616.747833,
     "geom:bbox":"29.79678,3.488987,32.169888,6.248087",
     "geom:latitude":4.76495,
     "geom:longitude":31.194042,
@@ -314,17 +314,19 @@
         "gn:id":408655,
         "gp:id":20069902,
         "hasc:id":"SS.BG",
+        "iso:code":"SS-EC",
         "iso:id":"SS-EC",
         "qs_pg:id":1118714,
         "unlc:id":"SS-EC",
         "wd:id":"Q487709",
         "wk:page":"Central Equatoria"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"b3a2d382dd9b8515b7f6af2f63f69ccc",
+    "wof:geomhash":"b6bd82a9dee6888bcb88f375a81ad661",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866740,
+    "wof:lastmodified":1695884837,
     "wof:name":"Central Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/53/85676953.geojson
+++ b/data/856/769/53/85676953.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":6.380394,
-    "geom:area_square_m":77708341459.837952,
+    "geom:area_square_m":77708342061.682373,
     "geom:bbox":"30.756117,7.979316,34.145517,12.236389",
     "geom:latitude":9.905604,
     "geom:longitude":32.80377,
@@ -312,16 +312,18 @@
         "gn:id":381229,
         "gp:id":20069908,
         "hasc:id":"SS.UN",
+        "iso:code":"SS-NU",
         "iso:id":"SS-NU",
         "qs_pg:id":1085723,
         "wd:id":"Q487702",
         "wk:page":"Upper Nile (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"df3b512b08fa0ff2f179233f433ab817",
+    "wof:geomhash":"d6523bfd2d30ebdbbe8f9cf044f5bb94",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866738,
+    "wof:lastmodified":1695884837,
     "wof:name":"Upper Nile",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/57/85676957.geojson
+++ b/data/856/769/57/85676957.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":9.987726,
-    "geom:area_square_m":122457211050.33429,
+    "geom:area_square_m":122457211533.849457,
     "geom:bbox":"30.209439,5.720021,35.022058,9.516082",
     "geom:latitude":7.388505,
     "geom:longitude":32.33267,
@@ -306,17 +306,19 @@
         "gn:id":408662,
         "gp:id":20069909,
         "hasc:id":"SS.JG",
+        "iso:code":"SS-JG",
         "iso:id":"SS-JG",
         "qs_pg:id":1118807,
         "unlc:id":"SS-JG",
         "wd:id":"Q488904",
         "wk:page":"Jonglei"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"aaa544074cd93ff31049b7b06078c348",
+    "wof:geomhash":"d8814e09d68a8938212c6103f1231fe4",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -331,7 +333,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866736,
+    "wof:lastmodified":1695884535,
     "wof:name":"Jungoli",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/63/85676963.geojson
+++ b/data/856/769/63/85676963.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.052091,
-    "geom:area_square_m":37279119088.540131,
+    "geom:area_square_m":37279119725.837364,
     "geom:bbox":"28.701851,7.068426,30.843851,10.288068",
     "geom:latitude":8.924838,
     "geom:longitude":29.888235,
@@ -311,17 +311,19 @@
         "gn:id":408650,
         "gp:id":20069907,
         "hasc:id":"SS.WH",
+        "iso:code":"SS-UY",
         "iso:id":"SS-UY",
         "qs_pg:id":959144,
         "unlc:id":"SS-UY",
         "wd:id":"Q319965",
         "wk:page":"Unity State"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"28435820fc031c3e9c0cabc133a10b58",
+    "wof:geomhash":"34861a9d9af322339563ed93ca27afdf",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -336,7 +338,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866739,
+    "wof:lastmodified":1695884838,
     "wof:name":"Unity",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/65/85676965.geojson
+++ b/data/856/769/65/85676965.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":3.80596,
-    "geom:area_square_m":46537050565.78891,
+    "geom:area_square_m":46537047733.426369,
     "geom:bbox":"27.833333,6.389177,29.703512,10.166667",
     "geom:latitude":8.51114,
     "geom:longitude":28.65596,
@@ -302,17 +302,19 @@
         "gn:id":408670,
         "gp:id":20069898,
         "hasc:id":"SS.WR",
+        "iso:code":"SS-WR",
         "iso:id":"SS-WR",
         "qs_pg:id":1186582,
         "unlc:id":"SS-WR",
         "wd:id":"Q491138",
         "wk:page":"Warrap (state)"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"238efc56246682fe6bef27e7df21b264",
+    "wof:geomhash":"f5848cd533e0b25edf02ac6dafbdc032",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -327,7 +329,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866738,
+    "wof:lastmodified":1695884536,
     "wof:name":"Warap",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/71/85676971.geojson
+++ b/data/856/769/71/85676971.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":8.522125,
-    "geom:area_square_m":104245779244.143967,
+    "geom:area_square_m":104245780404.2845,
     "geom:bbox":"23.440849,6.647834,28.534497,10.438989",
     "geom:latitude":8.349674,
     "geom:longitude":25.959824,
@@ -312,17 +312,19 @@
         "gn:id":408657,
         "gp:id":20069899,
         "hasc:id":"SS.WB",
+        "iso:code":"SS-BW",
         "iso:id":"SS-BW",
         "qs_pg:id":531454,
         "unlc:id":"SS-BW",
         "wd:id":"Q332095",
         "wk:page":"Western Bahr el Ghazal"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"bd1f663c3550e0dd8da4d6b74f06c9b9",
+    "wof:geomhash":"2a1dd4b0a8b194874375c46eb02457eb",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -337,7 +339,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866739,
+    "wof:lastmodified":1695884536,
     "wof:name":"West Bahr-al-Ghazal",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/856/769/75/85676975.geojson
+++ b/data/856/769/75/85676975.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":5.710248,
-    "geom:area_square_m":70345746625.884766,
+    "geom:area_square_m":70345746753.614014,
     "geom:bbox":"31.727594,3.50499,35.948997,6.001865",
     "geom:latitude":4.909347,
     "geom:longitude":33.524164,
@@ -314,17 +314,19 @@
         "gn:id":408668,
         "gp:id":20069901,
         "hasc:id":"SS.EE",
+        "iso:code":"SS-EE",
         "iso:id":"SS-EE",
         "qs_pg:id":221376,
         "unlc:id":"SS-EE",
         "wd:id":"Q488519",
         "wk:page":"Eastern Equatoria"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"SS",
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"81326a4e153827ab29a265d6274aff40",
+    "wof:geomhash":"b62f1db1d9dc13685bb95982478f042e",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -339,7 +341,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690866737,
+    "wof:lastmodified":1695884536,
     "wof:name":"East Equatoria",
     "wof:parent_id":85632657,
     "wof:placetype":"region",

--- a/data/890/452/095/890452095.geojson
+++ b/data/890/452/095/890452095.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.424757,
-    "geom:area_square_m":5239972525.952456,
+    "geom:area_square_m":5239971559.305503,
     "geom:bbox":"31.727594,3.50499,32.883262,4.364631",
     "geom:latitude":3.907688,
     "geom:longitude":32.212502,
@@ -98,12 +98,13 @@
         "wd:id":"Q1956550",
         "wk:page":"Magwi County"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"SS",
     "wof:created":1469052805,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"966d6d9a904198be658a9447c50ffb11",
+    "wof:geomhash":"1645e0c27b18f43af2cd35be44456012",
     "wof:hierarchy":[
         {
             "continent_id":102191573,
@@ -113,7 +114,7 @@
         }
     ],
     "wof:id":890452095,
-    "wof:lastmodified":1690866748,
+    "wof:lastmodified":1695886490,
     "wof:name":"Magwi",
     "wof:parent_id":85676975,
     "wof:placetype":"county",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.